### PR TITLE
feat(#3): add & configure liquibase migrations to create psql schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,36 @@
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>
+			<plugin>
+					<groupId>org.liquibase</groupId>
+					<artifactId>liquibase-maven-plugin</artifactId>
+					<version>5.0.3</version>
+					<configuration>
+						<propertyFile>src/main/resources/liquibase.yml</propertyFile>
+					</configuration>
+				<dependencies>
+					<dependency>
+						<groupId>org.liquibase.ext</groupId>
+						<artifactId>liquibase-hibernate7</artifactId>
+						<version>5.0.3</version>
+					</dependency>
+					<dependency>
+						<groupId>org.springframework.boot</groupId>
+						<artifactId>spring-boot-starter-data-jpa</artifactId>
+						<version>${project.parent.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>org.postgresql</groupId>
+						<artifactId>postgresql</artifactId>
+						<version>${postgresql.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>jakarta.validation</groupId>
+						<artifactId>jakarta.validation-api</artifactId>
+						<version>3.1.0</version>
+					</dependency>
+				</dependencies>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,6 +5,10 @@ spring:
     url: jdbc:postgresql://localhost:5432/velocity
     username: admin
     password: ${POSTGRES_PASSWORD:password}
+  jpa:
+    database-platform: org.hibernate.dialect.PostgreSQLDialect
+    hibernate:
+      ddl-auto: validate
 
 server:
   port: 8080

--- a/src/main/resources/db/changelog/001-create-users.xml
+++ b/src/main/resources/db/changelog/001-create-users.xml
@@ -1,0 +1,43 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+    <changeSet author="jakub-jurkian" id="create-user-table">
+        <createTable tableName="users">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="usersPK"/>
+            </column>
+            <column name="city" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="email" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="full_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="joined_date" type="date">
+                <constraints nullable="false"/>
+            </column>
+            <column name="password_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="phone" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="role" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="jakub-jurkian" id="add-unique-email-constraint">
+        <addUniqueConstraint columnNames="email" constraintName="UC_USERSEMAIL_COL" tableName="users"/>
+    </changeSet>
+    <changeSet author="jakub-jurkian" id="add-unique-phone-constraint">
+        <addUniqueConstraint columnNames="phone" constraintName="UC_USERSPHONE_COL" tableName="users"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/002-create-bike-models.xml
+++ b/src/main/resources/db/changelog/002-create-bike-models.xml
@@ -1,0 +1,35 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="jakub-jurkian" id="create-bike_models-table">
+        <createTable tableName="bike_models">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="bike_modelsPK"/>
+            </column>
+            <column name="capacity" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="category" type="SMALLINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="range" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+            <column name="speed" type="INTEGER">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="jakub-jurkian" id="1782985087770-5">
+        <addUniqueConstraint columnNames="name" constraintName="UC_BIKE_MODELSNAME_COL" tableName="bike_models"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/003-create-bike-instances.xml
+++ b/src/main/resources/db/changelog/003-create-bike-instances.xml
@@ -1,0 +1,29 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="jakub-jurkian" id="1782985087770-1">
+        <createTable tableName="bike_instances">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="bike_instancesPK"/>
+            </column>
+            <column name="city" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="bike_model_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="jakub-jurkian" id="1782985087770-8">
+        <addForeignKeyConstraint baseColumnNames="bike_model_id" baseTableName="bike_instances"
+                                 constraintName="fk_bike_model_on_bike_instance" deferrable="false"
+                                 initiallyDeferred="false" referencedColumnNames="id" referencedTableName="bike_models"
+                                 validate="true"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/004-create-reservations.xml
+++ b/src/main/resources/db/changelog/004-create-reservations.xml
@@ -1,0 +1,49 @@
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+
+    <changeSet author="jakub-jurkian" id="1782985087770-3">
+        <createTable tableName="reservations">
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true" primaryKeyName="reservationsPK"/>
+            </column>
+            <column name="created_at" type="TIMESTAMP(6) WITHOUT TIME ZONE">
+                <constraints nullable="false"/>
+            </column>
+            <column name="end_date" type="date">
+                <constraints nullable="false"/>
+            </column>
+            <column name="start_date" type="date">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="total_cost" type="numeric(38, 2)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="bike_instance_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="user_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet author="jakub-jurkian" id="1782985087770-9">
+        <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="reservations"
+                                 constraintName="fk_user_on_reservation" deferrable="false" initiallyDeferred="false"
+                                 referencedColumnNames="id" referencedTableName="users" validate="true"/>
+    </changeSet>
+    <changeSet author="jakub-jurkian" id="1782985087770-10">
+        <addForeignKeyConstraint baseColumnNames="bike_instance_id" baseTableName="reservations"
+                                 constraintName="fk_bike_instance_on_reservation" deferrable="false"
+                                 initiallyDeferred="false" referencedColumnNames="id"
+                                 referencedTableName="bike_instances" validate="true"/>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -2,3 +2,11 @@ databaseChangeLog:
   - preConditions:
       - runningAs:
           username: admin
+  - include:
+      file: db/changelog/001-create-users.xml
+  - include:
+      file: db/changelog/002-create-bike-models.xml
+  - include:
+      file: db/changelog/003-create-bike-instances.xml
+  - include:
+      file: db/changelog/004-create-reservations.xml

--- a/src/main/resources/liquibase.yml
+++ b/src/main/resources/liquibase.yml
@@ -1,0 +1,12 @@
+# TARGET (local PostgreSQL database)
+url: jdbc:postgresql://localhost:5432/velocity
+username: admin
+password: password
+driver: org.postgresql.Driver
+
+# REFERENCE (Java Code)
+referenceUrl: hibernate:spring:com.velocity.api?dialect=org.hibernate.dialect.PostgreSQLDialect
+
+# OUTPUT
+changeLogFile: src/main/resources/db/changelog/db.changelog-master.yaml
+diffChangeLogFile: src/main/resources/db/changelog/draft-migration.xml


### PR DESCRIPTION
## Context

This PR establishes our database migration pipeline by integrating Liquibase and creating the foundational PostgreSQL schema. This ensures our database structure is strictly version-controlled and completely synchronized with our existing JPA domain model.

Closes #5 


## Design Decisions

- Strict Schema Management: Transitioned spring.jpa.hibernate.ddl-auto to validate to prevent Hibernate from automatically altering tables. Liquibase is now the single source of truth for the database state.
- Naming Conventions: Manually mapped camelCase Java fields to standard snake_case database columns in the XML files to perfectly align with Spring Boot's default physical naming strategy.
- Atomic Migrations: Split the generated schema into sequential, atomic XML files (001 to 004) to cleanly resolve foreign key dependencies without circular references.
- Map Java types correctly to PostgreSQL native types (e.g., mapping UUID to uuid, BigDecimal to decimal/numeric, and @Version to bigint).
- Verified the migrations execute successfully against a local PostgreSQL instance and use a command liquibase:diff to ensure zero drift between the code and the database schema.

## What Changed

- Established the db/changelog/ directory structure and configured liquibase.yml for Maven integration.
- Created atomic XML migration scripts for users, bike_models, bike_instances, and reservations in strict dependency order.
- Configured db.changelog-master.yaml to orchestrate the execution order of the migration scripts.
- Explicitly defined all foreign keys, UNIQUE constraints, and NOT NULL rules at the database level to mirror JPA annotations.
- Mapped Java types to their native PostgreSQL equivalents (e.g., UUID to uuid, BigDecimal to numeric(38, 2), and @Version to bigint).


## Testing

- [x] Unit tests written and passing (N/A - infrastructure/schema only))
- [x] Application compiles and starts successfully ((Hibernate validate check passes))
- [x] Verified migrations execute successfully against a local PostgreSQL Docker container.
- [x] Verified mvn liquibase:diff shows zero drift between the entity code and the database schema.

## Notes FOR the Reviewer
- Note that the id attributes in the Liquibase <changeSet> blocks have been manually renamed from generated timestamps to human-readable actions to improve the databasechangelog audit trail.

- Local Dev Requirement: Ensure your local Docker PostgreSQL container is running before starting the application, as Spring Boot will now fail fast if the database is unreachable or mismatched.
