### PR TITLE
fix: update core domain entities to meet the business criteria entirely

### DIFF
--- a/src/main/java/com/velocity/api/bike/BikeCategory.java
+++ b/src/main/java/com/velocity/api/bike/BikeCategory.java
@@ -1,5 +1,7 @@
 package com.velocity.api.bike;
 
 public enum BikeCategory {
-    CARGO
+    AGILITY,       // "Agility"       — Sprint Courier S1
+    HEAVY_DUTY,    // "Heavy Duty"    — Cargo King XL
+    DUAL_BATTERY   // "Dual-battery system" — Endurance Pro 2.0
 }

--- a/src/main/java/com/velocity/api/bike/BikeInstance.java
+++ b/src/main/java/com/velocity/api/bike/BikeInstance.java
@@ -1,7 +1,7 @@
 package com.velocity.api.bike;
 
 import com.velocity.api.reservation.Reservation;
-import com.velocity.api.user.UserCity;
+import com.velocity.api.shared.City;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -23,7 +23,7 @@ public class BikeInstance {
     private BikeStatus status;
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private UserCity city;
+    private City city;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "bike_model_id", nullable = false)

--- a/src/main/java/com/velocity/api/bike/BikeModel.java
+++ b/src/main/java/com/velocity/api/bike/BikeModel.java
@@ -26,6 +26,7 @@ public class BikeModel {
     private int range;
     @Column(nullable = false)
     private int capacity;
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private BikeCategory category;
     @OneToMany(mappedBy = "bikeModel", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/velocity/api/shared/City.java
+++ b/src/main/java/com/velocity/api/shared/City.java
@@ -1,0 +1,5 @@
+package com.velocity.api.shared;
+
+public enum City {
+    GDANSK, WROCLAW, WARSAW, POZNAN
+}

--- a/src/main/java/com/velocity/api/user/User.java
+++ b/src/main/java/com/velocity/api/user/User.java
@@ -1,6 +1,7 @@
 package com.velocity.api.user;
 
 import com.velocity.api.reservation.Reservation;
+import com.velocity.api.shared.City;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -34,7 +35,7 @@ public class User {
     private UserRole role;
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    private UserCity city;
+    private City city;
     @Column(nullable = false, updatable = false)
     private LocalDate joinedDate;
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/velocity/api/user/UserCity.java
+++ b/src/main/java/com/velocity/api/user/UserCity.java
@@ -1,5 +1,0 @@
-package com.velocity.api.user;
-
-public enum UserCity {
-    GDANSK, WROCLAW, WARSAW, POZNAN
-}


### PR DESCRIPTION
## Context

Post-merge review of #2 revealed four domain-layer defects: an
incomplete enum, a missing JPA annotation causing silent data corruption,
and a cross-domain enum coupling.

Related to #2

## What Changed

- `BikeCategory` — replaced placeholder `CARGO` with the three values that
  match the frontend fleet catalogue: `AGILITY`, `HEAVY_DUTY`, `DUAL_BATTERY`

- `BikeModel.category` — added `@Enumerated(EnumType.STRING)` and
  `@Column(nullable = false)`; without `EnumType.STRING` JPA stores ordinal
  integers, so inserting a new enum value between existing ones silently
  corrupts all existing rows

- `City` — extracted from `UserCity` into `com.velocity.api.shared.City`;
  `BikeInstance.city` was borrowing a user-domain enum which created
  cross-domain coupling with no business justification; both `User` and
  `BikeInstance` now import from the shared package

## Testing

- [x] Unit tests written and passing (N/A just entity structure without logic)
- [x] Application compiles and starts successfully

## Notes FOR the Reviewer

The `City` move is the only change with a refactor footprint — two import
statements updated (`User`, `BikeInstance`). No logic changed, purely
structural. If we ever need per-domain city sets (e.g. bikes expand to
cities users can't register in), `shared.City` splits cleanly into two
enums with no entity changes needed.