### PR TITLE
feat: add error handlers

### DIFF
--- a/src/main/java/com/velocity/api/bike/BikeInstance.java
+++ b/src/main/java/com/velocity/api/bike/BikeInstance.java
@@ -1,7 +1,7 @@
 package com.velocity.api.bike;
 
 import com.velocity.api.reservation.Reservation;
-import com.velocity.api.shared.City;
+import com.velocity.api.common.City;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/velocity/api/bike/controller/FleetController.java
+++ b/src/main/java/com/velocity/api/bike/controller/FleetController.java
@@ -2,7 +2,7 @@ package com.velocity.api.bike.controller;
 
 import com.velocity.api.bike.dto.BikeInstanceDto;
 import com.velocity.api.bike.service.FleetService;
-import com.velocity.api.shared.dto.PaginatedResponse;
+import com.velocity.api.common.dto.PaginatedResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springdoc.core.annotations.ParameterObject;

--- a/src/main/java/com/velocity/api/bike/dto/BikeInstanceDto.java
+++ b/src/main/java/com/velocity/api/bike/dto/BikeInstanceDto.java
@@ -1,7 +1,7 @@
 package com.velocity.api.bike.dto;
 
 import com.velocity.api.bike.BikeStatus;
-import com.velocity.api.shared.City;
+import com.velocity.api.common.City;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/com/velocity/api/common/City.java
+++ b/src/main/java/com/velocity/api/common/City.java
@@ -1,4 +1,4 @@
-package com.velocity.api.shared;
+package com.velocity.api.common;
 
 public enum City {
     GDANSK, WROCLAW, WARSAW, POZNAN

--- a/src/main/java/com/velocity/api/common/dto/PaginatedResponse.java
+++ b/src/main/java/com/velocity/api/common/dto/PaginatedResponse.java
@@ -1,4 +1,4 @@
-package com.velocity.api.shared.dto;
+package com.velocity.api.common.dto;
 
 import java.util.List;
 

--- a/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,54 @@
+package com.velocity.api.common.exception;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.net.URI;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /**
+     * Catches HTTP 400 errors from @Valid on request bodies.
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ProblemDetail handleValidationExceptions(MethodArgumentNotValidException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                "The provided input data is invalid."
+        );
+        problem.setTitle("Validation Failed");
+        problem.setType(URI.create("about:blank"));
+        return problem;
+    }
+
+    @ExceptionHandler(ResourceNotFoundException.class)
+    public ProblemDetail handleNotFoundException(ResourceNotFoundException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.NOT_FOUND,
+                ex.getMessage()
+        );
+        problem.setTitle("Resource Not Found");
+        problem.setType(URI.create("about:blank"));
+
+        return problem;
+    }
+
+    /**
+     * This triggers when business rules clash (like double-booking a bike)
+     * or database constraints fail (like duplicate emails).
+     */
+    @ExceptionHandler({IllegalStateException.class, DataIntegrityViolationException.class})
+    public ProblemDetail handleConflictExceptions(RuntimeException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT,
+                "The request could not be completed due to a conflict with the current state of the resource. " + ex.getMessage());
+        problem.setTitle("Resource Conflict");
+        problem.setType(URI.create("about:blank"));
+
+        return problem;
+    }
+}

--- a/src/main/java/com/velocity/api/common/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/velocity/api/common/exception/ResourceNotFoundException.java
@@ -1,0 +1,11 @@
+package com.velocity.api.common.exception;
+
+/**
+ * A custom exception class.
+ * It's thrown whenever a database query comes up empty.
+ */
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/velocity/api/user/User.java
+++ b/src/main/java/com/velocity/api/user/User.java
@@ -1,7 +1,7 @@
 package com.velocity.api.user;
 
 import com.velocity.api.reservation.Reservation;
-import com.velocity.api.shared.City;
+import com.velocity.api.common.City;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;


### PR DESCRIPTION
## Context
This PR introduces a global exception-handling safety net. Before we start building write endpoints (like user registration), we need a standardized way to return errors to the frontend. This ensures that instead of crashing and returning an ugly HTML stack trace, the API gracefully returns structured JSON using the RFC 7807 `ProblemDetail` standard.

Closes #16 

## What Changed
- **Global Interceptor:** Created a `GlobalExceptionHandler` annotated with `@RestControllerAdvice` in the `common.exception` package to catch exceptions globally across all controllers.
- **Validation Errors (400):** Mapped Spring's built-in `MethodArgumentNotValidException` to a `400 Bad Request`. This prepares us to handle bad JSON inputs when we start using `@Valid` on our DTOs.
- **Missing Resources (404):** Created a custom `ResourceNotFoundException` class and mapped it to a `404 Not Found` response for when a database query comes up empty.
- **Business Conflicts (409):** Mapped `IllegalStateException` and `DataIntegrityViolationException` to a `409 Conflict`. This will catch business rule clashes and database constraint violations (like someone trying to register an email that already exists).

## Testing
- [x] Application compiles and starts successfully.
- [x] Verified that Spring Boot correctly intercepts and formats standard exceptions into `ProblemDetail` JSON objects.