### PR TITLE
Feature/7 register endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
             <scope>compile</scope>
             <version>3.0.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
@@ -3,11 +3,14 @@ package com.velocity.api.common.exception;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Global exception handler that intercepts exceptions thrown by the application
@@ -27,10 +30,19 @@ public class GlobalExceptionHandler {
     public ProblemDetail handleValidationExceptions(MethodArgumentNotValidException ex) {
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(
                 HttpStatus.BAD_REQUEST,
-                "The provided input data is invalid."
+                "Validation failed for one or more fields."
         );
-        problem.setTitle("Validation Failed");
+        problem.setTitle("Bad Request");
         problem.setType(URI.create("about:blank"));
+
+        Map<String, String> errors = new HashMap<>();
+
+        for (FieldError fieldError : ex.getBindingResult().getFieldErrors()) {
+            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+
+        problem.setProperty("invalidFields", errors);
+
         return problem;
     }
 
@@ -63,7 +75,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler({IllegalStateException.class, DataIntegrityViolationException.class})
     public ProblemDetail handleConflictExceptions(RuntimeException ex) {
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(HttpStatus.CONFLICT,
-                "The request could not be completed due to a conflict with the current state of the resource. " + ex.getMessage());
+                "The request could not be completed due to a conflict. The email or resource might already exist.");
         problem.setTitle("Resource Conflict");
         problem.setType(URI.create("about:blank"));
 

--- a/src/main/java/com/velocity/api/conf/SecurityConfig.java
+++ b/src/main/java/com/velocity/api/conf/SecurityConfig.java
@@ -1,0 +1,21 @@
+package com.velocity.api.conf;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * Global security configurations for the application.
+ * Currently limited to cryptographic beans to avoid premature HTTP lockdown.
+ */
+@Configuration
+public class SecurityConfig {
+    // tells Spring to run this method once, take the resulting
+    // BCryptPasswordEncoder object, and put it into the application context.
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/velocity/api/config/SecurityConfig.java
+++ b/src/main/java/com/velocity/api/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.velocity.api.conf;
+package com.velocity.api.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/com/velocity/api/user/controller/AuthController.java
+++ b/src/main/java/com/velocity/api/user/controller/AuthController.java
@@ -1,0 +1,36 @@
+package com.velocity.api.user.controller;
+
+import com.velocity.api.user.dto.UserRegistrationDto;
+import com.velocity.api.user.dto.UserRegistrationResponse;
+import com.velocity.api.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<UserRegistrationResponse> registerUser(@Valid @RequestBody UserRegistrationDto requestDto) {
+        UserRegistrationResponse createdUser = userService.registerUser(requestDto);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentContextPath()       // Gets http://localhost:8080
+                .path("/api/v1/users/{id}")     // The path to the future user profile
+                .buildAndExpand(createdUser.id()) // Replaces {id} with the real UUID
+                .toUri();
+
+        return ResponseEntity.created(location).body(createdUser);
+    }
+}

--- a/src/main/java/com/velocity/api/user/dto/UserRegistrationDto.java
+++ b/src/main/java/com/velocity/api/user/dto/UserRegistrationDto.java
@@ -1,0 +1,33 @@
+package com.velocity.api.user.dto;
+
+import com.velocity.api.common.City;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+
+@Valid
+public record UserRegistrationDto(
+        @NotBlank(message = "Email is required")
+        @Email(message = "Email must be properly formatted")
+        String email,
+        @NotBlank(message = "Password is required")
+        @Size(min = 8, max = 50, message = "Password must be between 8 and 50 characters")
+        String password,
+        @NotBlank(message = "Full name is required")
+        @Size(min = 2, max = 100, message = "Name must be between 2 and 100 characters")
+        String fullName,
+        @NotNull(message = "City is required")
+        City city,
+        @NotBlank(message = "Phone number is required")
+        @Pattern(regexp = "^\\+?[1-9]\\d{1,14}$", message = "Phone must be a valid international format (e.g., +48123456789)")
+        String phone
+) {
+    // compact constructor
+    public UserRegistrationDto {
+        if (email != null) {
+            email = email.toLowerCase().trim();
+        }
+        if (fullName != null) {
+            fullName = fullName.trim();
+        }
+    }
+}

--- a/src/main/java/com/velocity/api/user/dto/UserRegistrationResponse.java
+++ b/src/main/java/com/velocity/api/user/dto/UserRegistrationResponse.java
@@ -1,0 +1,16 @@
+package com.velocity.api.user.dto;
+
+import com.velocity.api.common.City;
+import com.velocity.api.user.UserRole;
+
+import java.util.UUID;
+
+// This record explicitly excludes the password hash to prevent data leaks
+public record UserRegistrationResponse(
+        UUID id,
+        String email,
+        String fullName,
+        String phone,
+        City city,
+        UserRole role
+) {}

--- a/src/main/java/com/velocity/api/user/repository/UserRepository.java
+++ b/src/main/java/com/velocity/api/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.velocity.api.user.repository;
+
+import com.velocity.api.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/velocity/api/user/service/UserService.java
+++ b/src/main/java/com/velocity/api/user/service/UserService.java
@@ -1,0 +1,53 @@
+package com.velocity.api.user.service;
+
+import com.velocity.api.user.User;
+import com.velocity.api.user.UserRole;
+import com.velocity.api.user.UserStatus;
+import com.velocity.api.user.dto.UserRegistrationDto;
+import com.velocity.api.user.dto.UserRegistrationResponse;
+import com.velocity.api.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    /**
+     * Registers a new client in the system.
+     *
+     * @param dto the validated registration payload
+     * @return UserRegistrationResponse safely omitting the password hash
+     * @throws IllegalStateException if the email is already in use
+     */
+    @Transactional // tells Spring this entire method is a single db transaction.
+    public UserRegistrationResponse registerUser(UserRegistrationDto dto) {
+        if (userRepository.existsByEmail(dto.email())) {
+            throw new IllegalStateException("Email is already registered");
+        }
+        ;
+        User user = new User();
+        user.setEmail(dto.email());
+        user.setFullName(dto.fullName());
+        user.setPhone(dto.phone());
+        user.setCity(dto.city());
+        user.setPasswordHash(passwordEncoder.encode(dto.password()));
+
+        user.setRole(UserRole.CLIENT);
+        user.setStatus(UserStatus.ACTIVE);
+
+        User savedUser = userRepository.save(user);
+
+        return new UserRegistrationResponse(
+                savedUser.getId(),
+                savedUser.getEmail(),
+                savedUser.getFullName(),
+                savedUser.getPhone(),
+                savedUser.getCity(),
+                savedUser.getRole()
+        );
+    }
+}


### PR DESCRIPTION
## Context
This PR introduces the first write REST API endpoint - POST /api/v1/auth/register - which allows users to create an account in the application. 
Closes #21 

## What Changed
- Implemented immutable Java `records` (`UserRegistrationDto`, `UserRegistrationResponse`) with Jakarta `@Valid` annotations to enforce strict data contracts at the controller level.
- Added `spring-security-crypto` and configured a generic `PasswordEncoder` bean (BCrypt) inside a new `SecurityConfig` to safely hash credentials before persistence.
- Built a transactional `UserService` that enforces business rules (duplicate email checks) and explicitly assigns the default `CLIENT` role.
- Upgraded the `GlobalExceptionHandler` to handle `MethodArgumentNotValidException` (returning a field-specific error map to the client) and `DataIntegrityViolationException` (strictly masking raw PostgreSQL constraint leaks).

## Testing
- [x] Application compiles and starts successfully
- [x] Manually verified `201 Created` via Swagger UI.
- [x] Manually verified database persists the BCrypt hash instead of the raw password.
- [x] Manually verified that duplicate emails trigger a clean `409 Conflict` and invalid formats trigger a `400 Bad Request` with mapped fields.