### PR TITLE
Test/11 test seam

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/src/test/java/com/velocity/api/security/ReservationIntegrationTest.java
+++ b/src/test/java/com/velocity/api/security/ReservationIntegrationTest.java
@@ -1,0 +1,48 @@
+package com.velocity.api.security;
+
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.security.core.Authentication;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.velocity.api.security.SecurityTestHelper.asUser;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+@SpringBootTest
+@WithMockCustomUser
+@AutoConfigureMockMvc
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL) // Tells JUnit to let Spring inject
+@RequiredArgsConstructor // creates constructor
+public class ReservationIntegrationTest {
+
+    private final MockMvc mockMvc;
+
+    @Test
+    void getAuthentication_customAnnotationPresent_returnsMockUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        assertNotNull(auth, "auth should not be null");
+        assertEquals("123e4567-e89b-12d3-a456-426614174000", auth.getName());
+    }
+
+    @Test
+    void perform_asUserHelperInjected_authenticatesRequest() throws Exception {
+        String testUserId = "999e4567-e89b-12d3-a456-426614174999";
+        mockMvc.perform(
+                        get("/v1/fake-endpoint-does-not-exist") // Fire at a fake URL
+                                .with(asUser(testUserId, "CLIENT"))     // <-- Inject our helper!
+                )
+                .andExpect(status().isNotFound())
+                .andExpect(authenticated().withUsername(testUserId))
+                .andExpect(authenticated().withRoles("CLIENT"));
+    }
+}

--- a/src/test/java/com/velocity/api/security/ReservationTest.java
+++ b/src/test/java/com/velocity/api/security/ReservationTest.java
@@ -1,7 +1,0 @@
-package com.velocity.api.security;
-
-import org.junit.jupiter.api.Test;
-
-@WithMockCustomUser
-public class ReservationTest {
-}

--- a/src/test/java/com/velocity/api/security/ReservationTest.java
+++ b/src/test/java/com/velocity/api/security/ReservationTest.java
@@ -1,0 +1,7 @@
+package com.velocity.api.security;
+
+import org.junit.jupiter.api.Test;
+
+@WithMockCustomUser
+public class ReservationTest {
+}

--- a/src/test/java/com/velocity/api/security/SecurityTestHelper.java
+++ b/src/test/java/com/velocity/api/security/SecurityTestHelper.java
@@ -1,0 +1,22 @@
+package com.velocity.api.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+
+public class SecurityTestHelper {
+    public static RequestPostProcessor asUser(String userId, String role) {
+        UserDetails dummyUser = User.builder()
+                .username(userId)
+                .password("password-not-needed")
+                .roles(role)
+                .build();
+
+        Authentication authTicket = new UsernamePasswordAuthenticationToken(dummyUser, null, dummyUser.getAuthorities());
+        return authentication(authTicket);
+    }
+}

--- a/src/test/java/com/velocity/api/security/WithMockCustomUser.java
+++ b/src/test/java/com/velocity/api/security/WithMockCustomUser.java
@@ -1,0 +1,13 @@
+package com.velocity.api.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserFactory.class)
+public @interface WithMockCustomUser {
+    String userId() default "123e4567-e89b-12d3-a456-426614174000";
+    String role() default "CLIENT";
+}

--- a/src/test/java/com/velocity/api/security/WithMockCustomUserFactory.java
+++ b/src/test/java/com/velocity/api/security/WithMockCustomUserFactory.java
@@ -1,0 +1,35 @@
+package com.velocity.api.security;
+
+import lombok.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithMockCustomUserFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    @NonNull
+    public SecurityContext createSecurityContext(@NonNull WithMockCustomUser annotation) {
+        // Extract the data from the annotation
+        String userId = annotation.userId();
+        String role = annotation.role();
+        // Build the UserDetails profile
+        UserDetails dummyUser = User.builder()
+                .username(userId)
+                .password("password-not-needed")
+                .roles(role)
+                .build();
+        // Print the Auth ticket
+        Authentication authTicket = new UsernamePasswordAuthenticationToken(dummyUser, null, dummyUser.getAuthorities());
+        // Create an empty SecurityContext and put ticket inside
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authTicket);
+
+        return context;
+    }
+}


### PR DESCRIPTION
## Context

This PR introduces a testing seam for integration tests, allowing us to simulate an authenticated user and bypass `401 Unauthorized` errors without needing to generate real cryptographic JWTs, as outlined in Issue #25.

Closes #25 

## What Changed

- Added the `spring-security-test` dependency to `pom.xml` (scoped strictly for tests).
- Created a custom `@WithMockCustomUser` annotation for declarative, method-level fake authentication.
- Implemented `WithMockCustomUserFactory` to translate the annotation into a Spring `UserDetails` profile and safely inject it into the `SecurityContext`.
- Created a `SecurityTestHelper` class with a static `asUser(userId, role)` method that returns a `RequestPostProcessor`, allowing programmatic user injection directly into `MockMvc` request chains.

## Testing

- [x] Unit tests written and passing
- [x] Application compiles and starts successfully

## Notes FOR the Reviewer

Please note that all test security utilities are explicitly located in `src/test/java/...` so they do not leak into the production build. 

Additionally, inside the Factory, `SecurityContextHolder.createEmptyContext()` is intentionally used rather than fetching the global context. This guarantees that our test threads remain isolated and do not pollute subsequent tests with leftover authentication state.