### PR TITLE
build: add Github Actions CI workflow for Maven tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set Up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Run Maven tests
+        run: mvn clean test


### PR DESCRIPTION
## Context

To implement Continuous Integration and protect our codebase, we need an automated gatekeeper. This ensures developers do not accidentally merge broken code by automatically running our test suite on a cloud runner every time new code is submitted.

Closes #12

## What Changed

- Created a `.github/workflows/ci.yml` file to define the GitHub Actions pipeline.
- Configured the workflow to trigger on `push` and `pull_request` events targeting the `main` branch.
- Provisioned an `ubuntu-latest` runner environment.
- Added steps to check out the repository using `actions/checkout@v4`.
- Set up JDK 25 (Temurin distribution) with Maven caching using `actions/setup-java@v4`.
- Added the execution step to run `mvn clean test`.

## Testing

- [x] Unit tests written and passing
- [x] Application compiles and starts successfully

## Notes FOR the Reviewer

The JDK version in the workflow is explicitly pinned to Java 25 to exactly match the `<java.version>` property in our `pom.xml`. Please note this pipeline acts purely as a CI gate for testing; deployment (CD) steps will be handled in a future issue.