### PR TITLE
Feature/13 reservation state machine

### DIFF
--- a/docs/adrs/0002-adopt-rich-domain-model-architecture.md
+++ b/docs/adrs/0002-adopt-rich-domain-model-architecture.md
@@ -1,0 +1,29 @@
+# ADR-002: Adopt Rich Domain Model Architecture
+
+## Status
+Accepted
+
+## Context
+As we build complex business workflows (such as the ebike Reservation state machine), we must decide where the core business rules live. Historically, many Spring Boot applications default to an "Anemic Domain Model," where entities are merely data containers (simple getters and setters), and all validation and state transition logic is scattered across various Service classes.
+
+We evaluated the trade-offs between continuing with an Anemic Domain Model versus adopting a Rich Domain Model, specifically for ensuring that entities cannot be forced into invalid or illegal states (e.g., transitioning a `CANCELLED` reservation directly to `COMPLETED`).
+
+## Decision
+We will adopt a **Rich Domain Model** architecture.
+
+Core business rules, state transitions, and internal validations will be encapsulated directly inside the JPA Entities.
+- Entities will expose behavior-driven methods (e.g., `transitionTo(ReservationStatus newStatus)`) rather than public setters for critical fields.
+- Entities are responsible for protecting their own invariants and throwing specific domain exceptions (e.g., `InvalidStatusTransitionException`) if an illegal operation is attempted.
+- Service classes will act strictly as orchestrators. A service will retrieve the entity, delegate the operation to the entity's behavioral method, and persist the result using Spring's `@Transactional` boundaries. Services will contain zero `if/else` logic regarding entity state validation.
+
+## Consequences
+
+### Positive
+- **Guaranteed Consistency:** It becomes programmatically impossible to save an entity in an invalid state, regardless of which controller, service, or background job modifies it.
+- **Improved Testability:** Core business rules can be exhaustively unit-tested using pure Java (e.g., `@ParameterizedTest` matrices) without needing Mockito or Spring Contexts.
+- **Thin Services:** Service classes become highly readable, focusing purely on orchestration (database fetching, transaction management, and external API calls).
+- **High Cohesion:** The data and the rules governing that data live in the exact same file.
+
+### Negative
+- **Learning Curve:** Developers accustomed to Anemic Domain Models must break the habit of putting business logic in Service classes and heavily utilizing Lombok `@Setter` on entities.
+- **Entity Size:** Entity classes will naturally grow larger in line count as they absorb the logic that previously lived in the service layer.

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,13 @@
                     </dependency>
                 </dependencies>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-XX:+EnableDynamicAgentLoading -Xshare:off</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
@@ -110,4 +110,15 @@ public class GlobalExceptionHandler {
 
         return problem;
     }
+
+    @ExceptionHandler(InvalidStatusTransitionException.class)
+    public ProblemDetail handleInvalidStatusTransitionException(InvalidStatusTransitionException ex) {
+        log.warn("Invalid State Change: {}", ex.getMessage());
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.UNPROCESSABLE_CONTENT,
+                ex.getMessage()
+        );
+        problem.setTitle("Invalid State Transition");
+        return problem;
+    }
 }

--- a/src/main/java/com/velocity/api/common/exception/InvalidStatusTransitionException.java
+++ b/src/main/java/com/velocity/api/common/exception/InvalidStatusTransitionException.java
@@ -1,0 +1,11 @@
+package com.velocity.api.common.exception;
+
+import com.velocity.api.reservation.ReservationStatus;
+
+public class InvalidStatusTransitionException extends RuntimeException {
+
+    // The constructor forces to provide the states
+    public InvalidStatusTransitionException(ReservationStatus from, ReservationStatus to) {
+        super(String.format("Invalid reservation state transition from %s to %s.", from, to));
+    }
+}

--- a/src/main/java/com/velocity/api/reservation/Reservation.java
+++ b/src/main/java/com/velocity/api/reservation/Reservation.java
@@ -1,8 +1,10 @@
 package com.velocity.api.reservation;
 
 import com.velocity.api.bike.BikeInstance;
+import com.velocity.api.common.exception.InvalidStatusTransitionException;
 import com.velocity.api.user.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -26,8 +28,9 @@ public class Reservation {
     @Column(nullable = false)
     private BigDecimal totalCost;
     @Column(nullable = false)
+    @Setter(AccessLevel.NONE)
     @Enumerated(EnumType.STRING)
-    private ReservationStatus status;
+    private ReservationStatus status = ReservationStatus.PENDING;
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
     @ManyToOne(fetch = FetchType.LAZY)
@@ -44,5 +47,25 @@ public class Reservation {
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
+    }
+
+    public void transitionTo(ReservationStatus newStatus) {
+        if (this.status == newStatus) return;
+
+        boolean isValid = switch (this.status) {
+            case PENDING -> newStatus == ReservationStatus.CONFIRMED || newStatus == ReservationStatus.CANCELLED;
+            case CONFIRMED -> newStatus == ReservationStatus.COMPLETED || newStatus == ReservationStatus.CANCELLED;
+            case CANCELLED, COMPLETED -> false;
+        };
+
+        if (!isValid) {
+            throw new InvalidStatusTransitionException(this.status, newStatus);
+        }
+
+        this.status = newStatus;
+    }
+
+    public void setStatusForTest(ReservationStatus newStatus) {
+        this.status = newStatus;
     }
 }

--- a/src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java
@@ -1,0 +1,9 @@
+package com.velocity.api.reservation.repository;
+
+import com.velocity.api.reservation.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface ReservationRepository extends JpaRepository<Reservation, UUID> {
+}

--- a/src/main/java/com/velocity/api/reservation/service/ReservationService.java
+++ b/src/main/java/com/velocity/api/reservation/service/ReservationService.java
@@ -1,0 +1,25 @@
+package com.velocity.api.reservation.service;
+
+import com.velocity.api.common.exception.ResourceNotFoundException;
+import com.velocity.api.reservation.Reservation;
+import com.velocity.api.reservation.ReservationStatus;
+import com.velocity.api.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+    private final ReservationRepository reservationRepository;
+
+    @Transactional
+    public void transition(UUID reservationId, ReservationStatus newStatus) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ResourceNotFoundException("Reservation not found: " + reservationId));
+        reservation.transitionTo(newStatus);
+        reservationRepository.save(reservation);
+    }
+}

--- a/src/test/java/com/velocity/api/reservation/ReservationServiceTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationServiceTest.java
@@ -1,5 +1,6 @@
 package com.velocity.api.reservation;
 
+import com.velocity.api.common.exception.InvalidStatusTransitionException;
 import com.velocity.api.common.exception.ResourceNotFoundException;
 import com.velocity.api.reservation.repository.ReservationRepository;
 import com.velocity.api.reservation.service.ReservationService;
@@ -14,7 +15,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class ReservationServiceTest {
@@ -32,5 +33,20 @@ public class ReservationServiceTest {
         assertThrows(ResourceNotFoundException.class, () -> {
             reservationService.transition(fakeId, ReservationStatus.CONFIRMED);
         });
+    }
+
+    @Test
+    @DisplayName("When transition is illegal, throws exception and does not save to database")
+    public void transition_illegalState_neverSaves() {
+        UUID validId = UUID.randomUUID();
+        Reservation pendingReservation = new Reservation();
+        pendingReservation.setStatusForTest(ReservationStatus.PENDING);
+
+        when(reservationRepository.findById(validId)).thenReturn(Optional.of(pendingReservation));
+        assertThrows(InvalidStatusTransitionException.class, () -> {
+            reservationService.transition(validId, ReservationStatus.COMPLETED);
+        });
+
+        verify(reservationRepository, never()).save(any(Reservation.class));
     }
 }

--- a/src/test/java/com/velocity/api/reservation/ReservationServiceTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationServiceTest.java
@@ -1,0 +1,36 @@
+package com.velocity.api.reservation;
+
+import com.velocity.api.common.exception.ResourceNotFoundException;
+import com.velocity.api.reservation.repository.ReservationRepository;
+import com.velocity.api.reservation.service.ReservationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ReservationServiceTest {
+    @Mock
+    private ReservationRepository reservationRepository;
+    @InjectMocks
+    private ReservationService reservationService;
+
+    @Test
+    @DisplayName("When reservation ID does not exist, transition throws ResourceNotFoundException")
+    public void transition_fakeID_throwsResourceNotFoundException() {
+        UUID fakeId = UUID.randomUUID();
+        when(reservationRepository.findById(fakeId)).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class, () -> {
+            reservationService.transition(fakeId, ReservationStatus.CONFIRMED);
+        });
+    }
+}

--- a/src/test/java/com/velocity/api/reservation/ReservationTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationTest.java
@@ -1,0 +1,72 @@
+package com.velocity.api.reservation;
+
+import com.velocity.api.common.exception.InvalidStatusTransitionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ReservationTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "PENDING, CONFIRMED",
+            "PENDING, CANCELLED",
+            "CONFIRMED, COMPLETED",
+            "CONFIRMED, CANCELLED"
+    })
+    @DisplayName("Valid state transitions should correctly update the reservation status")
+    public void transitionTo_validStates_updatesStatus(ReservationStatus from, ReservationStatus to) {
+        Reservation reservation = new Reservation();
+        reservation.setStatusForTest(from);
+
+        reservation.transitionTo(to);
+
+        assertEquals(to, reservation.getStatus());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "PENDING, COMPLETED",
+            "CONFIRMED, PENDING",
+            "CANCELLED, PENDING",
+            "CANCELLED, CONFIRMED",
+            "CANCELLED, COMPLETED",
+            "COMPLETED, PENDING",
+            "COMPLETED, CONFIRMED",
+            "COMPLETED, CANCELLED"
+    })
+    @DisplayName("Invalid state transitions should throw exception containing from and to states")
+    public void transitionTo_invalidStates_throwsInvalidStatusTransitionException(ReservationStatus from, ReservationStatus to) {
+        Reservation reservation = new Reservation();
+        reservation.setStatusForTest(from);
+
+        InvalidStatusTransitionException exception = assertThrows(InvalidStatusTransitionException.class, () -> {
+            reservation.transitionTo(to);
+        });
+
+        assertTrue(exception.getMessage().contains(from.name()),
+                "Message should contain FROM state: " + from);
+        assertTrue(exception.getMessage().contains(to.name()),
+                "Message should contain TO state: " + to);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "PENDING, PENDING",
+            "CONFIRMED, CONFIRMED",
+            "CANCELLED, CANCELLED",
+            "COMPLETED, COMPLETED"
+    })
+    @DisplayName("Same-state transitions should act as a safe no-op")
+    public void transitionTo_sameState_doesNothing(ReservationStatus from, ReservationStatus to) {
+        Reservation reservation = new Reservation();
+        reservation.setStatusForTest(from);
+
+        reservation.transitionTo(to);
+
+        assertEquals(to, reservation.getStatus());
+    }
+}


### PR DESCRIPTION
## Context

This PR implements the strict state machine requirements. We needed a secure way to guarantee that a reservation cannot be forced into an illegal state (e.g., jumping directly from `CANCELLED` to `COMPLETED`). 

Following the newly established architectural guidelines, this implementation shifts the validation logic out of the service layer and directly into the entity.

Closes #33 

## What Changed

- **Added ADR-002:** Officially documented the decision to adopt a Rich Domain Model to encapsulate business rules within domain entities.
- **Rich Domain Model Implementation:** Added `transitionTo(ReservationStatus newStatus)` in the `Reservation` entity using a Java `switch` expression to enforce the whitelist of allowed state transitions.
- **Custom Exception:** Created `InvalidStatusTransitionException` to capture and expose both the `from` and `to` states upon an illegal transition attempt.
- **Service Orchestration:** Implemented `ReservationService.transition()`. The service fetches the entity, delegates the state change to the entity, and persists it using `@Transactional`.
- **Global Error Handling:** Updated `GlobalExceptionHandler` to intercept `InvalidStatusTransitionException`. It now logs the attempt at the `WARN` level and returns a standardized RFC 7807 `ProblemDetail` mapped to HTTP 422 (Unprocessable Content).

## Testing

- [x] Unit tests written and passing
  - Tested the entity's state matrix using `@ParameterizedTest` and `@CsvSource` to cover valid, invalid, and same-state transitions.
  - Implemented Mockito tests for `ReservationServiceTest` to ensure `ResourceNotFoundException` is thrown for non-existent IDs.
  - Added a Mockito `verify(..., never())` test to mathematically prove that illegal transitions halt execution and do not trigger a database save.
- [x] Application compiles and starts successfully