### PR TITLE
chore: move business logic check to constructor from method | remove …

### DIFF
--- a/src/main/java/com/velocity/api/billing/RentalCostCalculator.java
+++ b/src/main/java/com/velocity/api/billing/RentalCostCalculator.java
@@ -10,18 +10,16 @@ public class RentalCostCalculator {
     private final BigDecimal dailyFlatRate;
 
     public RentalCostCalculator(@Value("${pricing.daily-rate}") BigDecimal dailyFlatRate) {
+        if (dailyFlatRate.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("The flat rate should be greater a non-negative value.");
+        }
         this.dailyFlatRate = dailyFlatRate;
     }
 
     public BigDecimal calculate(int rentalDays) {
-        if(rentalDays <= 0) {
+        if (rentalDays <= 0) {
             throw new IllegalArgumentException("The rental days should be greater than 0.");
         }
-
-        if(dailyFlatRate.compareTo(BigDecimal.ZERO) < 0) {
-            throw new IllegalArgumentException("The flat rate should be greater a non-negative value.");
-        }
-
         return this.dailyFlatRate.multiply(BigDecimal.valueOf(rentalDays));
     }
 }

--- a/src/main/java/com/velocity/api/reservation/service/ReservationService.java
+++ b/src/main/java/com/velocity/api/reservation/service/ReservationService.java
@@ -20,6 +20,5 @@ public class ReservationService {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ResourceNotFoundException("Reservation not found: " + reservationId));
         reservation.transitionTo(newStatus);
-        reservationRepository.save(reservation);
     }
 }

--- a/src/main/java/com/velocity/api/user/controller/AuthController.java
+++ b/src/main/java/com/velocity/api/user/controller/AuthController.java
@@ -4,7 +4,6 @@ import com.velocity.api.user.dto.UserRegistrationDto;
 import com.velocity.api.user.dto.UserRegistrationResponse;
 import com.velocity.api.user.service.UserService;
 import jakarta.validation.Valid;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;


### PR DESCRIPTION
## Context
This PR introduces low-risk consistency and correctness polish. It resolves a fail-fast configuration issue and standardizes our approach to JPA transactions before we introduce the client-facing reservation endpoints.

Closes #36 

## What Changed
- **Fail-Fast Validation:** Moved the negative `dailyFlatRate` check into the `RentalCostCalculator` constructor. An invalid pricing configuration will now correctly crash the application at startup rather than failing dynamically during a method call. 
- **Transaction Standardization:** Removed the redundant `reservationRepository.save()` call in `ReservationService.transition()`. We are officially relying on Hibernate's dirty checking inside `@Transactional` methods to automatically flush state changes to the database.

## Testing
- [x] Unit tests written and passing
- [x] Application compiles and starts successfully

## Notes FOR the Reviewer
- Notice that `RentalCostCalculator.calculate()` still retains the `rentalDays <= 0` check, as that is dynamic input per-call. Only the static configuration validation was moved to the bean creation phase.