### PR TITLE
Docs/ai workflow context setup

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,28 @@
+### Type
+<!-- Feature / Bug / Chore / Tech Debt / Polish-batch -->
+
+### Context
+[Why this is needed. For a single change: the problem and goal. For a batch: why these are grouped, why now, what breaks if deferred.]
+
+<!-- For batches, number the sub-items here with rationale inline: -->
+<!-- 1. **[Short title].** [What's wrong, where, why it matters] -->
+<!-- 2. **[Short title].** [What's wrong, where, why it matters] -->
+
+### Acceptance Criteria
+- [ ] [Actionable, testable requirement — one per sub-item if batched]
+- [ ] `mvn clean test` is green
+
+<!-- Optional — include only if relevant to this issue: -->
+
+### Technical Notes
+- **Location:**
+- **Environment:**
+- **Execution:**
+- **Scope:**
+
+### Dependencies
+- Blocked by:
+- Blocks:
+
+### Risks / Edge Cases
+<!-- concurrency, race conditions, data migration risk, etc. -->

--- a/docs/adrs/0003-adopt-project-context-file-with-ai-assistant-grounding.md
+++ b/docs/adrs/0003-adopt-project-context-file-with-ai-assistant-grounding.md
@@ -1,0 +1,71 @@
+## Status
+Accepted
+
+## Context
+This project is built solo, with an AI assistant (Gemini, Claude) used as an active pair-programming
+partner throughout the development workflow — theory review, issue creation, branch work,
+and PR generation. This differs from typical AI-assisted development in that the AI is
+treated as a consistent team member across the full lifecycle, not an occasional autocomplete
+tool.
+
+In practice, this exposed a structural limitation common to all general-purpose chat LLMs:
+finite context windows and session statelessness. Once a chat grew long enough, or a new
+session was started, the assistant lost track of the domain model (`User`, `BikeModel`,
+`BikeInstance`, `Reservation`), established architectural rules (e.g. optimistic locking vs.
+database-level overlap constraints), and the repo's issue/PR template conventions. This
+caused repeated re-explanation, and in several cases the assistant generated issues and PRs
+using invented structures instead of the project's actual templates.
+
+We evaluated three approaches: (1) switching to a different AI model or provider, (2) relying
+purely on longer, more careful prompting within each session, and (3) externalizing project
+context into the repository itself and grounding the assistant in it explicitly. Switching
+models does not address the underlying cause — statelessness is a property of all current
+chat LLMs, not a specific provider. Relying on prompting alone does not survive new sessions
+and does not scale as the domain model and rule set grow.
+
+## Decision
+We will treat **AI context management as a documented part of the engineering workflow**,
+not an ad hoc habit, using two artifacts:
+
+- **`docs/context/PROJECT_CONTEXT.md`** — a committed, single-source-of-truth file covering
+  stack, domain model, architectural rules with rationale, explicitly rejected anti-patterns,
+  a domain glossary, conventions (templates, commit style, branching), and current sprint
+  status. This file is treated as living documentation: updated at the end of each closed
+  issue, not retroactively.
+- **A configured Gemini Gem**, grounded in `PROJECT_CONTEXT.md` via attached knowledge, with
+  system instructions that (a) require reading the context file before generating any
+  issue, PR, or technical suggestion, (b) enforce exact adherence to existing templates
+  rather than inventing new structures, (c) default to explanation-first, code-on-request
+  behavior to support learning rather than blind code generation, and (d) require the
+  assistant to flag stale or missing context rather than guess.
+
+GitHub Copilot (installed in IntelliJ IDEA) is not included in this decision. Its role in
+the workflow is unresolved and left as an open question — see Consequences.
+
+## Consequences
+
+### Positive
+- **Portable grounding:** Any AI assistant (not just Gemini) can be grounded correctly by
+  reading a single, version-controlled file, rather than depending on chat history.
+- **Consistency at scale:** Issue and PR generation now reliably follows the repo's actual
+  templates instead of assistant-invented structures.
+- **Reduced repetition:** Domain model, schema, and architectural rules no longer need to be
+  re-explained at the start of every session.
+- **Documentation as a side effect:** The context file is independently useful to a human
+  reviewer or future contributor, not just to AI — it doubles as onboarding documentation.
+- **Forces explicit rationale:** Writing "why" alongside every architectural rule (not just
+  "what") surfaces decisions that would otherwise stay implicit.
+
+### Negative
+- **Maintenance burden:** The context file and Gem knowledge attachments are not
+  auto-synced with the codebase. A stale context file actively misleads rather than
+  helping, which requires discipline to keep updated after every merged PR.
+- **Does not eliminate in-session drift:** Grounding fixes cold-start amnesia at the start
+  of a new chat, but does not prevent context degradation within a single long-running
+  session. Long sessions still require manual restart discipline.
+- **Two sources of truth risk:** The Gem's attached knowledge and the repo's actual
+  `PROJECT_CONTEXT.md` can diverge if the Gem file isn't re-uploaded after edits.
+- **Open question — Copilot's role:** GitHub Copilot is installed but not yet integrated
+  into this workflow or governed by this ADR. Its fit (in-IDE, codebase-indexed assistance
+  vs. chat-based Gem) is still being evaluated and may be addressed in a future ADR or
+  issue if adopted.

--- a/docs/context/PROJECT_CONTEXT.md
+++ b/docs/context/PROJECT_CONTEXT.md
@@ -1,0 +1,157 @@
+# VeloCity Fleet API - AI Context
+
+Last updated: 2026-07-27
+
+> Single source of truth for AI assistants and contributors.
+> Keep this file aligned with the codebase, schema, ADRs, and delivery plan.
+
+## 1. Purpose
+
+Read this before changing code, generating issues, or opening PRs. This project is a Spring Boot backend for an e-bike rental platform. The important constraints are not "generic CRUD" constraints; they are reservation integrity, money accuracy, and clear API boundaries.
+
+## 2. Stack
+
+- Java 25
+- Spring Boot 4.1.0
+- Spring Data JPA / Hibernate
+- PostgreSQL 16
+- Liquibase
+- Maven
+- JUnit 5
+- Mockito
+- Spring Security crypto + spring-security-test
+- springdoc-openapi
+
+Notes:
+- DTOs are used at controller boundaries, but MapStruct is not wired in yet.
+- No JWT implementation exists yet.
+- No Testcontainers usage exists yet.
+
+## 3. Domain Model
+
+### User
+
+- Fields: `id`, `email`, `passwordHash`, `fullName`, `phone`, `status`, `role`, `city`, `joinedDate`
+- Relationships: `User -> Reservation` one-to-many
+- Rules:
+  - `email` and `phone` are unique.
+  - `joinedDate` is set in `@PrePersist`.
+  - Registration always stores a BCrypt hash, never a plain password.
+
+### BikeModel
+
+- Fields: `id`, `name`, `description`, `speed`, `range`, `capacity`, `category`
+- Relationships: `BikeModel -> BikeInstance` one-to-many
+- Rules:
+  - `name` is unique.
+  - This is the abstract bike type, not a physical bike.
+
+### BikeInstance
+
+- Fields: `id`, `status`, `city`, `bikeModel`
+- Status enum: `ACTIVE`, `MAINTENANCE`, `LOST`, `RETIRED`
+- Relationships:
+  - `BikeInstance -> BikeModel` many-to-one
+  - `BikeInstance -> Reservation` one-to-many
+- Rules:
+  - Availability queries currently treat `ACTIVE` bikes as bookable.
+  - There is no bike status transition service yet.
+
+### Reservation
+
+- Fields: `id`, `startDate`, `endDate`, `totalCost`, `status`, `createdAt`, `version`, `user`, `bikeInstance`
+- Status enum: `PENDING`, `CONFIRMED`, `COMPLETED`, `CANCELLED`
+- Relationships:
+  - `Reservation -> User` many-to-one
+  - `Reservation -> BikeInstance` many-to-one
+- Rules:
+  - `totalCost` is a persisted snapshot.
+  - `createdAt` is set in `@PrePersist`.
+  - `@Version` exists for lost-update protection on updates to an existing row.
+  - Valid transitions:
+    - `PENDING -> CONFIRMED`
+    - `PENDING -> CANCELLED`
+    - `CONFIRMED -> COMPLETED`
+    - `CONFIRMED -> CANCELLED`
+  - Invalid transitions throw `InvalidStatusTransitionException`.
+
+## 4. Architectural Rules
+
+- **DTOs at every controller boundary.** Entities do not leave the service layer, which keeps persistence details and lazy-loading concerns out of the API contract.
+- **Money uses `BigDecimal` only.** This avoids floating-point rounding errors in rental pricing.
+- **Reservation overlap is enforced in PostgreSQL.** The hard guarantee is a Liquibase-managed exclusion constraint on active reservations using `daterange(..., '[)')` and `btree_gist`; service-side checks are only for friendlier 409 responses.
+- **`@Version` is for update races, not booking overlap.** It protects state changes on existing reservation rows, not the initial insert race.
+- **Status transitions stay out of controllers.** Reservation lifecycle rules live in the domain entity and service layer so they stay testable and centralized.
+- **List endpoints return paged responses.** The current pattern is `Page<T>` in the service and `PaginatedResponse<T>` at the API boundary.
+- **Validation lives on request DTOs.** `@Valid`, bean validation annotations, and `ProblemDetail` responses are the standard.
+- **Liquibase is the schema source of truth.** `spring.jpa.hibernate.ddl-auto=validate` is intentional.
+- **`open-in-view` stays off.** Controllers must not rely on lazy entity access after transaction boundaries.
+- **Passwords are always hashed with BCrypt.** Plain-text passwords must never be persisted or returned.
+
+## 5. Anti-Patterns
+
+- No field injection
+- No entities returned from controllers
+- No business logic in controllers
+- No trusting client-sent prices
+- No double-booking by application-side check-then-act logic
+- No `double` or `float` for money
+- No changing reservation state from the controller layer
+
+## 6. Glossary
+
+- **BikeModel** - the abstract bike type, such as a product line or spec sheet
+- **BikeInstance** - one physical bike with its own ID, city, status, and model reference
+- **Reservation** - a booking for one bike instance over a date range
+- **Active reservation** - a reservation with status `PENDING` or `CONFIRMED`
+
+## 7. Conventions
+
+- Issue template: `.github/issue_template.md`
+- PR template: `.github/pull_request_template.md`
+- Commit style: conventional commits are used in history (`docs: ...`, `feat: ...`, etc.)
+- Branch naming: concise slash-separated names are used in practice, for example `docs/update-readme`
+- Testing: JUnit 5 + Mockito, with parameterized domain tests and thin integration tests
+- CI: GitHub Actions runs `mvn clean test` on `main` against PostgreSQL 16 and JDK 25
+- API docs: Swagger UI at `/api/swagger-ui.html`, OpenAPI JSON at `/api/api-docs`
+
+## 8. Current Sprint / Where I Am
+
+- Day 27/90
+- Last completed: core domain entities, rental calculator, auth registration, fleet listing, RFC 7807 error handling, Liquibase schema, and seed data
+- In progress: the working API/security phase from the 90-day plan
+- Next up: reservation creation flow, concurrency-safe booking enforcement, and JWT-based security
+
+## 9. Reference, Don't Duplicate
+
+- Full schema: `src/main/resources/db/changelog/`
+- Runtime config: `src/main/resources/application.yaml`
+- Liquibase config: `src/main/resources/liquibase.yml`
+- ADRs:
+  - `docs/adrs/0001-prevent-reservation-race-conditions.md`
+  - `docs/adrs/0002-adopt-rich-domain-model-architecture.md`
+- API docs: Springdoc OpenAPI
+
+## 10. Current API Surface
+
+- `POST /api/v1/auth/register`
+- `GET /api/v1/fleet`
+
+## 11. Current Implementation Notes
+
+- `UserService` handles registration and uses `PasswordEncoder`.
+- `FleetService` returns only active bike instances.
+- `ReservationService` currently supports status transitions for an existing reservation by ID.
+- `GlobalExceptionHandler` maps validation failures, missing resources, conflicts, invalid transitions, and uncaught exceptions to `ProblemDetail`.
+- There is no reservation create endpoint yet.
+- There is no JWT filter, token service, or login endpoint yet.
+- The current mapper is handwritten (`BikeInstanceMapper`), not MapStruct-generated.
+
+## 12. Plan Alignment
+
+The 90-day plan in `VeloCity_Fleet_API_Plan_90_Days.docx` is a guide, not a perfect match for current code. Current code already includes a few additions and corrections:
+
+- Rich domain behavior for reservations is implemented.
+- Pricing is server-side and BigDecimal-based.
+- Reservation overlap strategy follows ADR-001 and uses a database constraint, not optimistic locking alone.
+- Security is only partially present so far.


### PR DESCRIPTION
### Context
Establishes a repeatable fix for AI context loss across Gemini sessions by committing a single-source-of-truth project context file and configuring a Gemini Gem grounded in it.

Closes #42 

### Changes
- Added `docs/context/PROJECT_CONTEXT.md` — stack, domain model, architectural rules with rationale, anti-patterns, glossary, conventions, current sprint status
- Configured Gemini Gem with instructions enforcing context grounding, template adherence, and explanation-before-code default behavior

### Acceptance Criteria
- [x] PROJECT_CONTEXT.md created and committed
- [x] Gemini Gem created and configured
- [x] Gem tested for context recall and template adherence
- [x] `mvn clean test` is green

### Out of Scope
GitHub Copilot's role in the workflow - installed, evaluation pending, tracked as an open question in ADR-0003.

### Notes for Reviewer
Documentation/process-only change, no application code affected.