### PR TITLE
Database Concurrency Integration Tests for E-Bike Reservations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,17 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-restclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-resttestclient</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/src/main/java/com/velocity/api/bike/BikeInstance.java
+++ b/src/main/java/com/velocity/api/bike/BikeInstance.java
@@ -3,17 +3,18 @@ package com.velocity.api.bike;
 import com.velocity.api.reservation.Reservation;
 import com.velocity.api.common.City;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 @Getter
-@Setter
 @Entity
 @Table(name = "bike_instances")
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class BikeInstance {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -30,5 +31,11 @@ public class BikeInstance {
     private BikeModel bikeModel;
 
     @OneToMany(mappedBy = "bikeInstance")
-    private List<Reservation> reservations = new ArrayList<>();
+    private final List<Reservation> reservations = new ArrayList<>();
+
+    public BikeInstance(BikeModel bikeModel, City city) {
+        this.bikeModel = bikeModel;
+        this.city = city;
+        this.status = BikeStatus.ACTIVE; // Default state for a new physical bike
+    }
 }

--- a/src/main/java/com/velocity/api/bike/BikeModel.java
+++ b/src/main/java/com/velocity/api/bike/BikeModel.java
@@ -1,7 +1,9 @@
 package com.velocity.api.bike;
 
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.ArrayList;
@@ -12,6 +14,7 @@ import java.util.UUID;
 @Setter
 @Entity
 @Table(name = "bike_models")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BikeModel {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -30,5 +33,14 @@ public class BikeModel {
     @Column(nullable = false)
     private BikeCategory category;
     @OneToMany(mappedBy = "bikeModel")
-    private List<BikeInstance> bikeInstances = new ArrayList<>();
+    private final List<BikeInstance> bikeInstances = new ArrayList<>();
+
+    public BikeModel(String name, String description, int speed, int range, int capacity, BikeCategory category) {
+        this.name = name;
+        this.description = description;
+        this.speed = speed;
+        this.range = range;
+        this.capacity = capacity;
+        this.category = category;
+    }
 }

--- a/src/main/java/com/velocity/api/bike/repository/BikeModelRepository.java
+++ b/src/main/java/com/velocity/api/bike/repository/BikeModelRepository.java
@@ -1,0 +1,9 @@
+package com.velocity.api.bike.repository;
+
+import com.velocity.api.bike.BikeModel;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface BikeModelRepository extends JpaRepository<BikeModel, UUID> {
+}

--- a/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.velocity.api.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
@@ -97,8 +99,8 @@ public class GlobalExceptionHandler {
      * @param ex the data integrity violation exception
      * @return a ProblemDetail object explaining the specific conflict
      */
-    @ExceptionHandler(DataIntegrityViolationException.class)
-    public ProblemDetail handleDataIntegrityViolationException(DataIntegrityViolationException ex) {
+    @ExceptionHandler({DataIntegrityViolationException.class, CannotAcquireLockException.class})
+    public ProblemDetail handleDataIntegrityViolationException(DataAccessException ex) {
         log.warn("Database integrity violation occurred: {}", ex.getMessage());
 
         String detail = "A database conflict occurred.";

--- a/src/main/java/com/velocity/api/reservation/Reservation.java
+++ b/src/main/java/com/velocity/api/reservation/Reservation.java
@@ -14,7 +14,6 @@ import java.time.Instant;
 import java.util.UUID;
 
 @Getter
-@Setter
 @Entity
 @Table(name = "reservations")
 public class Reservation {

--- a/src/main/java/com/velocity/api/reservation/Reservation.java
+++ b/src/main/java/com/velocity/api/reservation/Reservation.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 import java.util.UUID;
 
 @Getter
+@Setter
 @Entity
 @Table(name = "reservations")
 public class Reservation {

--- a/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
+++ b/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,7 +24,7 @@ public class ReservationController {
     public ResponseEntity<ReservationResponse> createReservation(
             // TODO: Ensure the incoming request payload is validated
             // TODO: Extract authenticated user ID instead of a random mock
-            @Valid ReservationCreateRequest req
+            @Valid @RequestBody ReservationCreateRequest req
     ) {
         UUID authenticatedUserId = UUID.fromString("00000000-0000-0000-0000-000000000001");
         ReservationResponse response = reservationService.createReservation(authenticatedUserId, req);

--- a/src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 
 public interface ReservationRepository extends JpaRepository<Reservation, UUID> {
     @Query("""
-              SELECT EXISTS(
+              SELECT NOT EXISTS(
                 SELECT 1 FROM Reservation r
                   WHERE r.bikeInstance.id = :bikeId
                     AND r.status IN ('PENDING', 'CONFIRMED')

--- a/src/main/java/com/velocity/api/reservation/service/ReservationService.java
+++ b/src/main/java/com/velocity/api/reservation/service/ReservationService.java
@@ -37,6 +37,7 @@ public class ReservationService {
         reservation.transitionTo(newStatus);
     }
 
+    @Transactional
     public ReservationResponse createReservation(UUID userId, ReservationCreateRequest req) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));

--- a/src/main/java/com/velocity/api/user/User.java
+++ b/src/main/java/com/velocity/api/user/User.java
@@ -3,8 +3,9 @@ package com.velocity.api.user;
 import com.velocity.api.reservation.Reservation;
 import com.velocity.api.common.City;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -12,9 +13,9 @@ import java.util.List;
 import java.util.UUID;
 
 @Getter
-@Setter
 @Entity
 @Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // for JPA
 public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -39,7 +40,7 @@ public class User {
     @Column(nullable = false, updatable = false)
     private LocalDate joinedDate;
     @OneToMany(mappedBy = "user")
-    private List<Reservation> reservations = new ArrayList<>();
+    final private List<Reservation> reservations = new ArrayList<>();
 
     @PrePersist
     protected void onCreate() {
@@ -49,5 +50,15 @@ public class User {
     public void addReservation(Reservation reservation) {
         reservations.add(reservation);
         reservation.setUser(this); // Syncing the other side
+    }
+
+    public User(String email, String passwordHash, String fullName, String phone, UserRole role, City city) {
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.fullName = fullName;
+        this.phone = phone;
+        this.role = role;
+        this.city = city;
+        this.status = UserStatus.ACTIVE;
     }
 }

--- a/src/main/java/com/velocity/api/user/service/UserService.java
+++ b/src/main/java/com/velocity/api/user/service/UserService.java
@@ -32,15 +32,7 @@ public class UserService {
         if (userRepository.existsByEmail(dto.email())) {
             throw new EmailAlreadyRegisteredException("The email address " + dto.email() + " is already in use.");
         }
-        User user = new User();
-        user.setEmail(dto.email());
-        user.setFullName(dto.fullName());
-        user.setPhone(dto.phone());
-        user.setCity(dto.city());
-        user.setPasswordHash(passwordEncoder.encode(dto.password()));
-
-        user.setRole(UserRole.CLIENT);
-        user.setStatus(UserStatus.ACTIVE);
+        User user = new User(dto.email(), passwordEncoder.encode(dto.password()), dto.fullName(), dto.phone(), UserRole.CLIENT, dto.city());
 
         User savedUser = userRepository.save(user);
         log.info("Successfully registered new user with ID: {} and email: {}", savedUser.getId(), savedUser.getEmail());

--- a/src/test/java/com/velocity/api/reservation/ReservationConcurrencyIntegrationTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationConcurrencyIntegrationTest.java
@@ -1,0 +1,109 @@
+package com.velocity.api.reservation;
+
+import com.velocity.api.bike.BikeCategory;
+import com.velocity.api.bike.BikeInstance;
+import com.velocity.api.bike.BikeModel;
+import com.velocity.api.bike.repository.BikeInstanceRepository;
+import com.velocity.api.bike.repository.BikeModelRepository;
+import com.velocity.api.reservation.dto.ReservationCreateRequest;
+import com.velocity.api.reservation.repository.ReservationRepository;
+import com.velocity.api.common.City;
+import com.velocity.api.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+// default - webEnvironment = WebEnvironment.MOCK - does not start real web server (creates mock servlet env in memory)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@AutoConfigureTestRestTemplate
+public class ReservationConcurrencyIntegrationTest {
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+    @Autowired
+    private TestRestTemplate testRestTemplate;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private BikeModelRepository bikeModelRepository;
+    @Autowired
+    private BikeInstanceRepository bikeInstanceRepository;
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    private UUID bikeInstanceId;
+
+    @BeforeEach
+    public void setUp() {
+        jdbcTemplate.update(
+                "INSERT INTO users (id, email, password_hash, full_name, phone, status, role, city, joined_date) " +
+                        "VALUES ('00000000-0000-0000-0000-000000000001', 'test@test.com', 'hash', 'Test', '123', 'ACTIVE', 'CLIENT', 'WARSAW', now())"
+        );
+        // force the hardcoded user into DB cause id is hardcoded in controller right now
+        // User savedUser = userRepository.save(new User("test@test.com", "xf843fd23iom4r", "Test", "+48000000000", UserRole.CLIENT, City.GDANSK));
+        BikeModel savedBikeModel = bikeModelRepository.save(new BikeModel("Test", "Test", 100, 100, 50, BikeCategory.AGILITY));
+        BikeInstance savedBikeInstance = bikeInstanceRepository.save(new BikeInstance(savedBikeModel, City.GDANSK));
+        bikeInstanceId = savedBikeInstance.getId();
+    }
+
+    @AfterEach
+    public void cleanUp() {
+        reservationRepository.deleteAll();
+        bikeInstanceRepository.deleteAll();
+        bikeModelRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    public void shouldReturnConflictOnConcurrentOverlappingReservations() throws ExecutionException, InterruptedException {
+        // prep the req
+        ReservationCreateRequest req = new ReservationCreateRequest(bikeInstanceId, LocalDate.parse("2026-09-05"), LocalDate.parse("2026-09-10"));
+
+        // init concurrency tools
+        CountDownLatch latch = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        // Define the work to be done by the threads
+        Callable<ResponseEntity<String>> bookingTask = () -> {
+            // Freeze the thread until the main test thread drops the gate
+            latch.await();
+            // Fire the POST request to the controller
+            return testRestTemplate.postForEntity("/api/v1/reservations", req, String.class);
+        };
+
+        try {
+            // Hand the identical task to the executor twice
+            Future<ResponseEntity<String>> task1 = executor.submit(bookingTask);
+            Future<ResponseEntity<String>> task2 = executor.submit(bookingTask);
+
+            latch.countDown();
+
+            ResponseEntity<String> res1 = task1.get();
+            ResponseEntity<String> res2 = task2.get();
+            HttpStatus status1 = (HttpStatus) res1.getStatusCode();
+            HttpStatus status2 = (HttpStatus) res2.getStatusCode();
+            System.out.println("Response 1 Body: " + res1.getBody());
+            System.out.println("Response 2 Body: " + res2.getBody());
+            // assert that one is 201 and second one is 409
+            List<HttpStatus> statuses = List.of(status1, status2);
+            assertThat(statuses).containsExactlyInAnyOrder(HttpStatus.CREATED, HttpStatus.CONFLICT);
+        } finally {
+            executor.shutdown();
+        }
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,5 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/velocity_test
+    username: admin
+    password: password


### PR DESCRIPTION
## Context

This PR introduces the integration tests required to prove our database-level concurrency guarantees for e-bike reservations, as outlined in ADR-001. It also addresses several binding and transaction lifecycle bugs discovered during the implementation of the concurrent test scenario.

Closes #45 

## What Changed

- Added the explicit Spring Boot 4 `spring-boot-restclient` and `spring-boot-resttestclient` modules.
- Added the missing `@RequestBody` annotation to `ReservationController.createReservation()` to ensure Jackson properly binds the JSON payload to the Java record.
- Shifted the transaction boundary by adding `@Transactional` to `ReservationService.createReservation()`. This keeps the Hibernate session open through the entire method, preventing `LazyInitializationException` when building the response DTO.
- Broadened the signature in `GlobalExceptionHandler` to accept `DataAccessException`. This ensures that both standard `DataIntegrityViolationException` and PostgreSQL GiST deadlocks (`CannotAcquireLockException`) are correctly intercepted and mapped to an HTTP 409 Conflict.
- Added `ReservationConcurrencyIntegrationTest` to deterministically prove that overlapping concurrent requests are rejected by the database exclusion constraint.

## Testing

- [x] Unit tests written and passing
- [x] Application compiles and starts successfully

## Notes for the Reviewer

The most notable change here is treating `CannotAcquireLockException` as a standard 409 Conflict. Because PostgreSQL's `btree_gist` extension uses physical index-page locks to evaluate date ranges, simultaneous inserts can cause internal deadlocks. From a business perspective, this simply means the user lost the booking race, so we handle it gracefully rather than letting it bubble up as a 500 Internal Server Error.