### PR TITLE
fix: add velocity_test db to CI postgres service

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         env:
           POSTGRES_USER: admin
           POSTGRES_PASSWORD: password
-          POSTGRES_DB: velocity
+          POSTGRES_DB: velocity_test
         ports:
           - 5432:5432
         options: >-

--- a/src/test/java/com/velocity/api/VelocityApiApplicationTests.java
+++ b/src/test/java/com/velocity/api/VelocityApiApplicationTests.java
@@ -2,8 +2,10 @@ package com.velocity.api;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class VelocityApiApplicationTests {
 
 	@Test

--- a/src/test/java/com/velocity/api/security/AuthenticationIntegrationTest.java
+++ b/src/test/java/com/velocity/api/security/AuthenticationIntegrationTest.java
@@ -7,6 +7,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.security.core.Authentication;
 
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -22,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL) // Tells JUnit to let Spring inject
 @RequiredArgsConstructor // creates constructor
+@ActiveProfiles("test")
 public class AuthenticationIntegrationTest {
 
     private final MockMvc mockMvc;


### PR DESCRIPTION
fix CI pipline by changing POSTGRES_DB env variable from  'velocity' to 'velocity_test' which is required by new intergration test.