### PR TITLE
Feat/implement bike availability check

### DIFF
--- a/src/main/java/com/velocity/api/bike/repository/BikeInstanceRepository.java
+++ b/src/main/java/com/velocity/api/bike/repository/BikeInstanceRepository.java
@@ -2,12 +2,26 @@ package com.velocity.api.bike.repository;
 
 import com.velocity.api.bike.BikeInstance;
 import com.velocity.api.bike.BikeStatus;
+import com.velocity.api.bike.repository.projection.AvailableModelProjection;
+import org.springframework.cglib.core.Local;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 public interface BikeInstanceRepository extends JpaRepository<BikeInstance, UUID> {
-    public Page<BikeInstance> findByStatus(BikeStatus status, Pageable pageable);
+    Page<BikeInstance> findByStatus(BikeStatus status, Pageable pageable);
+
+    @Query(nativeQuery = true, value = """
+                SELECT DISTINCT ON (m.id) i.id AS bookableInstanceId, m.name AS modelName, m.description AS modelDescription, m.speed AS modelSpeed, m.range AS modelRange, m.capacity AS modelCapacity, m.category AS modelCategory FROM bike_instances i JOIN bike_models m ON i.bike_model_id = m.id WHERE i.status = 'ACTIVE' AND NOT EXISTS (SELECT 1 FROM reservations r WHERE r.bike_instance_id = i.id
+                AND r.status IN ('PENDING', 'CONFIRMED')
+                AND daterange(CAST(:startDate AS date), CAST(:endDate AS date), '[)') && daterange(r.start_date, r.end_date, '[)')
+                );
+            """)
+    List<AvailableModelProjection> findAvailableModels(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/com/velocity/api/bike/repository/projection/AvailableModelProjection.java
+++ b/src/main/java/com/velocity/api/bike/repository/projection/AvailableModelProjection.java
@@ -1,0 +1,15 @@
+package com.velocity.api.bike.repository.projection;
+
+import com.velocity.api.bike.BikeCategory;
+
+import java.util.UUID;
+
+public interface AvailableModelProjection {
+    UUID getBookableInstanceId();
+    String getModelName();
+    String getModelDescription();
+    int getModelSpeed();
+    int getModelRange();
+    int getModelCapacity();
+    BikeCategory getModelCategory();
+}

--- a/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
@@ -182,6 +182,17 @@ public class GlobalExceptionHandler {
         return problem;
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ProblemDetail handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.warn("Invalid arguments: {}", ex.getMessage());
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                ex.getMessage()
+        );
+        problem.setTitle("Invalid arguments");
+        return problem;
+    }
+
     /**
      * Fallback handler for any unhandled exceptions.
      * Maps to HTTP 500 Internal Server Error.

--- a/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
+++ b/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
@@ -1,5 +1,6 @@
 package com.velocity.api.reservation.controller;
 
+import com.velocity.api.reservation.dto.AvailableModelResponse;
 import com.velocity.api.reservation.dto.ReservationCreateRequest;
 import com.velocity.api.reservation.dto.ReservationResponse;
 import com.velocity.api.reservation.service.ReservationService;
@@ -7,11 +8,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.function.EntityResponse;
 
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -34,8 +35,9 @@ public class ReservationController {
                 .body(response);
     }
 
-    @PostMapping
-    public ResponseEntity<> checkFleetAvailability() {
-        // TODO: Returns an aggregated list of models available for the requested dates.
+    @GetMapping("/availability")
+    public ResponseEntity<List<AvailableModelResponse>> getAvailableModels(@RequestParam LocalDate startDate, @RequestParam LocalDate endDate) {
+        List<AvailableModelResponse> response = reservationService.getAvailableModels(startDate, endDate);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
+++ b/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
@@ -33,4 +33,9 @@ public class ReservationController {
                 .status(HttpStatus.CREATED)
                 .body(response);
     }
+
+    @PostMapping
+    public ResponseEntity<> checkFleetAvailability() {
+        // TODO: Returns an aggregated list of models available for the requested dates.
+    }
 }

--- a/src/main/java/com/velocity/api/reservation/dto/AvailableModelResponse.java
+++ b/src/main/java/com/velocity/api/reservation/dto/AvailableModelResponse.java
@@ -1,0 +1,18 @@
+package com.velocity.api.reservation.dto;
+
+import com.velocity.api.bike.BikeCategory;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record AvailableModelResponse(
+        UUID bookableInstanceId,
+        String modelName,
+        String modelDescription,
+        int modelSpeed,
+        int modelRange,
+        int modelCapacity,
+        BikeCategory modelCategory,
+        BigDecimal totalCost
+) {
+}

--- a/src/main/java/com/velocity/api/reservation/service/ReservationService.java
+++ b/src/main/java/com/velocity/api/reservation/service/ReservationService.java
@@ -3,23 +3,28 @@ package com.velocity.api.reservation.service;
 import com.velocity.api.bike.BikeInstance;
 import com.velocity.api.bike.BikeStatus;
 import com.velocity.api.bike.repository.BikeInstanceRepository;
+import com.velocity.api.bike.repository.projection.AvailableModelProjection;
 import com.velocity.api.billing.RentalCostCalculator;
 import com.velocity.api.common.exception.BikeNotAvailableException;
 import com.velocity.api.common.exception.InvalidBikeStateException;
 import com.velocity.api.common.exception.ResourceNotFoundException;
 import com.velocity.api.reservation.Reservation;
 import com.velocity.api.reservation.ReservationStatus;
+import com.velocity.api.reservation.dto.AvailableModelResponse;
 import com.velocity.api.reservation.dto.ReservationCreateRequest;
 import com.velocity.api.reservation.dto.ReservationResponse;
 import com.velocity.api.reservation.repository.ReservationRepository;
 import com.velocity.api.user.User;
 import com.velocity.api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -67,5 +72,24 @@ public class ReservationService {
                 savedReservation.getCreatedAt(),
                 bikeSummary
         );
+    }
+
+    public List<AvailableModelResponse> getAvailableModels(LocalDate startDate, LocalDate endDate) {
+        List<AvailableModelProjection> response = bikeInstanceRepository.findAvailableModels(startDate, endDate);
+        int days = Math.toIntExact(ChronoUnit.DAYS.between(startDate, endDate));
+        BigDecimal totalCost = rentalCostCalculator.calculate(days);
+        return response.stream().map(projection ->
+                        new AvailableModelResponse(
+                                projection.getBookableInstanceId(),
+                                projection.getModelName(),
+                                projection.getModelDescription(),
+                                projection.getModelSpeed(),
+                                projection.getModelRange(),
+                                projection.getModelCapacity(),
+                                projection.getModelCategory(),
+                                totalCost
+                        )
+                )
+                .toList();
     }
 }


### PR DESCRIPTION
## Context

This PR introduces the implementation of checking bike availability (`GET /api/v1/reservations/availability?startDate={date}&endDate={date}` endpoint). Right now, a client can type the start and end dates of a reservation, and a complex query is sent to the database through the backend to check if specific bike models have an `ACTIVE` physical instance available for that exact date range.

Closes #48 

## What Changed

- **Native PostgreSQL Query:** Implemented a `@Query(nativeQuery = true)` in `BikeInstanceRepository` using `DISTINCT ON (m.id)` to return only one physical instance per model.
- **ADR-001 Alignment:** Integrated GiST `daterange(..., '[)') && daterange(..., '[)')` overlap logic directly into the native query's `NOT EXISTS` block to perfectly match our database exclusion constraint bounds.
- **JPA Projections:** Created an `AvailableModelProjection` interface to map the raw SQL result set into Java getters via property aliases, avoiding the overhead of Hibernate entity tracking.
- **Service Orchestration & Pricing:** Wired up `ReservationService` to fetch projections and map them to a new `AvailableModelResponse` DTO. Integrated the `RentalCostCalculator` to compute the exact price once per request (since all models cost the same flat rate) and apply it to all available models in the stream.
- **Edge-Case Error Handling:** Added an `IllegalArgumentException` handler to `GlobalExceptionHandler` to gracefully return a `400 Bad Request` (RFC-7807 format) if the client requests a 0-day rental (e.g., identical start and end dates).

## Testing

- [ ] Unit tests written and passing
- [ ] Application compiles and starts successfully

## Notes FOR the Reviewer

Please pay special attention to the native SQL query in `BikeInstanceRepository`. Specifically, verify that the `daterange` explicit casts and `[)` bounds perfectly match the Liquibase exclusion constraint defined in ADR-001. 