### PR TITLE
feat(#52: scheduled-jobs-implementation

### DIFF
--- a/docs/context/PROJECT_CONTEXT.md
+++ b/docs/context/PROJECT_CONTEXT.md
@@ -1,6 +1,6 @@
 # VeloCity Fleet API - AI Context
 
-Last updated: 2026-07-29
+Last updated: 2026-08-10
 
 > Single source of truth for AI assistants and contributors.
 > Keep this file aligned with the codebase, schema, ADRs, and delivery plan.
@@ -117,10 +117,11 @@ Notes:
 
 ## 8. Current Sprint / Where I Am
 
-- Day 29/90
-- Last completed: core domain entities, rental calculator, auth registration, fleet listing, RFC 7807 error handling, Liquibase schema, seed data, and the reservation creation endpoint with database-level concurrency enforcement (Issue #14)
-- In progress: the working API/security phase from the 90-day plan
-- Next up: reservation conflict integration testing and availability search
+- Day 41/90
+- Last completed: reservation conflict integration testing (#15), bike availability check (#16), and domain layer refactoring to strictly enforce ADR-002 (removed public setters/constructors, added static factory methods).
+- In progress: @Scheduled jobs for reservation lifecycle management (auto-complete rentals & auto-cancel stale PENDING) (#18).
+- Next up: Optimistic-lock conflict handling on updates (#17) and N+1 query diagnosis (#19).
+
 ## 9. Reference, Don't Duplicate
 
 - Full schema: `src/main/resources/db/changelog/`
@@ -135,17 +136,21 @@ Notes:
 
 - `POST /api/v1/auth/register`
 - `GET /api/v1/fleet`
-- - `POST /api/v1/reservations`
+- `POST /api/v1/reservations`
+- `GET /api/v1/reservations/availability`
 
 ## 11. Current Implementation Notes
 
 - `UserService` handles registration and uses `PasswordEncoder`.
 - `FleetService` returns only active bike instances.
+- Core domain entities (`Reservation`, `User`, `BikeModel`, `BikeInstance`) fully comply with ADR-002, utilizing protected constructors and static factory methods to prevent invalid state instantiation.
 - `ReservationService` orchestrates cost calculation, persistence, and status assignment for new bookings.
-- `GlobalExceptionHandler` maps validation failures, missing resources, conflicts (including intelligent root-cause inspection for PostgreSQL exclusion constraints), invalid bike states, invalid status transitions, and uncaught exceptions to `ProblemDetail`[cite: 1, 3].
+- `GlobalExceptionHandler` maps validation failures, missing resources, conflicts (including intelligent root-cause inspection for PostgreSQL exclusion constraints), invalid bike states, invalid status transitions, and uncaught exceptions to `ProblemDetail`.
+- Paginated responses (like `/api/v1/fleet`) are wrapped in a generic `PaginatedResponse<T>` envelope with static factory mapping to decouple API contracts from Spring Data `Page` objects.
 - Reservation creation endpoint (`POST /api/v1/reservations`) is fully implemented with DTO protection and `@Valid` date-range validation.
 - There is no JWT filter, token service, or login endpoint yet.
 - The current mapper is handwritten (`BikeInstanceMapper`), not MapStruct-generated.
+
 ## 12. Plan Alignment
 
 The 90-day plan in `VeloCity_Fleet_API_Plan_90_Days.docx` is a guide, not a perfect match for current code. Current code already includes a few additions and corrections:

--- a/src/main/java/com/velocity/api/VelocityApiApplication.java
+++ b/src/main/java/com/velocity/api/VelocityApiApplication.java
@@ -2,7 +2,9 @@ package com.velocity.api;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class VelocityApiApplication {
 

--- a/src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java
@@ -1,22 +1,31 @@
 package com.velocity.api.reservation.repository;
 
 import com.velocity.api.reservation.Reservation;
+import com.velocity.api.reservation.ReservationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.Instant;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
 
 public interface ReservationRepository extends JpaRepository<Reservation, UUID> {
     @Query("""
-              SELECT NOT EXISTS(
-                SELECT 1 FROM Reservation r
-                  WHERE r.bikeInstance.id = :bikeId
-                    AND r.status IN ('PENDING', 'CONFIRMED')
-                    AND r.startDate < :endDate
-                    AND r.endDate > :startDate
-              )
-    """)
+                      SELECT NOT EXISTS(
+                        SELECT 1 FROM Reservation r
+                          WHERE r.bikeInstance.id = :bikeId
+                            AND r.status IN ('PENDING', 'CONFIRMED')
+                            AND r.startDate < :endDate
+                            AND r.endDate > :startDate
+                      )
+            """)
     public boolean isBikeAvailable(@Param("bikeId") UUID bikeId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+
+    @Query("SELECT r.id FROM Reservation r WHERE r.status = :status AND r.createdAt < :cutoff")
+    public List<UUID> findStalePendingReservationsIds(@Param("status") ReservationStatus status, @Param("cutoff") Instant cutoff);
+
+    @Query("SELECT r.id FROM Reservation r WHERE r.status = :status AND r.endDate < :today")
+    public List<UUID> findPastDueConfirmedReservationsIds(@Param("status") ReservationStatus status, @Param("today") LocalDate today);
 }

--- a/src/main/java/com/velocity/api/reservation/scheduler/ReservationLifecycleScheduler.java
+++ b/src/main/java/com/velocity/api/reservation/scheduler/ReservationLifecycleScheduler.java
@@ -1,0 +1,58 @@
+package com.velocity.api.reservation.scheduler;
+
+import com.velocity.api.reservation.ReservationStatus;
+import com.velocity.api.reservation.repository.ReservationRepository;
+import com.velocity.api.reservation.service.ReservationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReservationLifecycleScheduler {
+    private final ReservationRepository reservationRepository;
+    private final ReservationService reservationService;
+
+    // @Scheduled(fixedRate = 60000)
+    @Scheduled(fixedRate = 10000)
+    public void cancelStalePendingReservations() {
+        Instant cutoff = Instant.now().minus(30, ChronoUnit.MINUTES);
+        List<UUID> stalePendingReservationIds = reservationRepository.findStalePendingReservationsIds(ReservationStatus.PENDING, cutoff);
+
+        for (UUID id : stalePendingReservationIds) {
+            try {
+                reservationService.cancelStaleReservation(id);
+            } catch (ObjectOptimisticLockingFailureException e) {
+                log.warn("Reservation {} already modified.", id);
+            } catch (Exception e) {
+                log.error("Unexpected error processing reservation {}", id, e);
+            }
+        }
+    }
+
+    // @Scheduled(cron = "0 1 0 * * *")
+    @Scheduled(fixedRate = 10000) // for testing
+    public void completePastDueConfirmedReservations() {
+
+        List<UUID> pastDueConfirmedReservationIds = reservationRepository.findPastDueConfirmedReservationsIds(ReservationStatus.CONFIRMED, LocalDate.now());
+
+        for (UUID id : pastDueConfirmedReservationIds) {
+            try {
+                reservationService.completePastDueConfirmedReservations(id);
+            } catch (ObjectOptimisticLockingFailureException e) {
+                log.warn("Reservation {} already modified.", id);
+            } catch (Exception e) {
+                log.error("Unexpected error processing reservation {}", id, e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/velocity/api/reservation/service/ReservationService.java
+++ b/src/main/java/com/velocity/api/reservation/service/ReservationService.java
@@ -102,4 +102,18 @@ public class ReservationService {
                 )
                 .toList();
     }
+
+    @Transactional // if not added, status will be updated in Java memory only.
+    public void cancelStaleReservation(UUID id) {
+        Reservation staleReservation = reservationRepository.findById(id).orElseThrow(
+                () -> new ResourceNotFoundException("Reservation not found"));
+        staleReservation.transitionTo(ReservationStatus.CANCELLED);
+    }
+
+    @Transactional
+    public void completePastDueConfirmedReservations(UUID id) {
+        Reservation pastDueConfirmedReservation = reservationRepository.findById(id).orElseThrow(
+                () -> new ResourceNotFoundException("Reservation not found"));
+        pastDueConfirmedReservation.transitionTo(ReservationStatus.COMPLETED);
+    }
 }

--- a/src/test/java/com/velocity/api/factory/TestDataFactory.java
+++ b/src/test/java/com/velocity/api/factory/TestDataFactory.java
@@ -1,0 +1,66 @@
+package com.velocity.api.factory;
+
+import com.velocity.api.bike.BikeCategory;
+import com.velocity.api.bike.BikeInstance;
+import com.velocity.api.bike.BikeModel;
+import com.velocity.api.bike.repository.BikeInstanceRepository;
+import com.velocity.api.bike.repository.BikeModelRepository;
+import com.velocity.api.common.City;
+import com.velocity.api.reservation.Reservation;
+import com.velocity.api.reservation.repository.ReservationRepository;
+import com.velocity.api.user.User;
+import com.velocity.api.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.UUID;
+
+@TestComponent
+@RequiredArgsConstructor
+public class TestDataFactory {
+    // Inject repositories via constructor
+    private final UserRepository userRepository;
+    private final BikeModelRepository bikeModelRepository;
+    private final BikeInstanceRepository bikeInstanceRepository;
+    private final ReservationRepository reservationRepository;
+
+    // Create reusable methods
+    public User createAndSaveDefaultUser() {
+        User testUser = User.registerClient(
+                "test.user@velocity.com",
+                "hashed_pw",
+                "Integration Test User",
+                "+48123456789",
+                City.WARSAW
+        );
+        return userRepository.save(testUser);
+    }
+
+    public BikeInstance createAndSaveDefaultBike() {
+        BikeModel testModel = BikeModel.create(
+                "Integration Test Model " + UUID.randomUUID(),
+                "Test description",
+                45,
+                80,
+                40,
+                BikeCategory.AGILITY
+        );
+        bikeModelRepository.save(testModel);
+
+        BikeInstance testBike = BikeInstance.initialize(testModel, City.WARSAW);
+        return bikeInstanceRepository.save(testBike);
+    }
+
+    public Reservation createAndSaveReservation(User user, BikeInstance bikeInstance, LocalDate startDate, LocalDate endDate) {
+        Reservation normalReservation = Reservation.book(
+                user,
+                bikeInstance,
+                startDate,
+                endDate,
+                BigDecimal.ONE
+        );
+        return reservationRepository.save(normalReservation);
+    }
+}

--- a/src/test/java/com/velocity/api/reservation/ReservationConcurrencyIntegrationTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationConcurrencyIntegrationTest.java
@@ -70,7 +70,7 @@ public class ReservationConcurrencyIntegrationTest {
     }
 
     @Test
-    public void shouldReturnConflictOnConcurrentOverlappingReservations() throws ExecutionException, InterruptedException {
+    public void createReservation_ConcurrentIdenticalRequests_ReturnsCreatedAndConflict() throws ExecutionException, InterruptedException {
         // prep the req
         ReservationBookRequest req = new ReservationBookRequest(bikeInstanceId, LocalDate.parse("2026-09-05"), LocalDate.parse("2026-09-10"));
 

--- a/src/test/java/com/velocity/api/reservation/scheduler/ReservationSchedulerIntegrationTest.java
+++ b/src/test/java/com/velocity/api/reservation/scheduler/ReservationSchedulerIntegrationTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -25,6 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @ActiveProfiles("test")
+@Import(TestDataFactory.class) // This explicitly pulls the factory into the test context
 public class ReservationSchedulerIntegrationTest {
     @Autowired
     private ReservationLifecycleScheduler scheduler;

--- a/src/test/java/com/velocity/api/reservation/scheduler/ReservationSchedulerIntegrationTest.java
+++ b/src/test/java/com/velocity/api/reservation/scheduler/ReservationSchedulerIntegrationTest.java
@@ -1,0 +1,103 @@
+package com.velocity.api.reservation.scheduler;
+
+import com.velocity.api.bike.BikeInstance;
+import com.velocity.api.bike.repository.BikeInstanceRepository;
+import com.velocity.api.bike.repository.BikeModelRepository;
+import com.velocity.api.factory.TestDataFactory;
+import com.velocity.api.reservation.Reservation;
+import com.velocity.api.reservation.ReservationStatus;
+import com.velocity.api.reservation.repository.ReservationRepository;
+import com.velocity.api.user.User;
+import com.velocity.api.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class ReservationSchedulerIntegrationTest {
+    @Autowired
+    private ReservationLifecycleScheduler scheduler;
+    @Autowired
+    private ReservationRepository reservationRepository;
+    @Autowired
+    private BikeInstanceRepository bikeInstanceRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private BikeModelRepository bikeModelRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private TestDataFactory testDataFactory;
+
+    @AfterEach
+    public void cleanUp() {
+        reservationRepository.deleteAll();
+        bikeInstanceRepository.deleteAll();
+        bikeModelRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    public void cancelStalePendingReservations_OlderThan30Minutes_changeReservationsStateToCancelled() {
+        // Arrange: Create explicit test data to satisfy Foreign Key constraints
+
+        User testUser = testDataFactory.createAndSaveDefaultUser();
+        BikeInstance testBike = testDataFactory.createAndSaveDefaultBike();
+        Reservation bookedNormalReservation = testDataFactory.createAndSaveReservation(
+                testUser, testBike, LocalDate.parse("2026-09-05"), LocalDate.parse("2026-09-10")
+        );
+
+        Reservation bookedStaleReservation = testDataFactory.createAndSaveReservation(
+                testUser, testBike, LocalDate.parse("2026-10-05"), LocalDate.parse("2026-10-10")
+        );
+        //The Database Backdoor: Force the timestamp 7 days into the past
+        jdbcTemplate.update("UPDATE reservations SET created_at = ? WHERE id = ?",
+                Timestamp.from(Instant.now().minus(7, ChronoUnit.DAYS)),
+                bookedStaleReservation.getId());
+        // Act
+        scheduler.cancelStalePendingReservations();
+
+        Reservation updatedNormalReservation = reservationRepository.findById(bookedNormalReservation.getId()).orElseThrow();
+        Reservation updatedStaleReservation = reservationRepository.findById(bookedStaleReservation.getId()).orElseThrow();
+        // Assert
+        assertEquals(ReservationStatus.PENDING, updatedNormalReservation.getStatus());
+        assertEquals(ReservationStatus.CANCELLED, updatedStaleReservation.getStatus());
+    }
+
+    @Test
+    public void completePastDueReservations_EndDateInPast_UpdatesStatusToCompleted() {
+        User testUser = testDataFactory.createAndSaveDefaultUser();
+        BikeInstance testBike = testDataFactory.createAndSaveDefaultBike();
+        Reservation bookedNormalReservation = testDataFactory.createAndSaveReservation(
+                testUser, testBike, LocalDate.parse("2026-09-05"), LocalDate.parse("2026-09-10")
+        );
+
+        Reservation pastDueReservation = testDataFactory.createAndSaveReservation(
+                testUser, testBike, LocalDate.parse("2026-08-01"), LocalDate.parse("2026-08-08")
+        );
+        pastDueReservation.transitionTo(ReservationStatus.CONFIRMED);
+        Reservation bookedPastDueReservation = reservationRepository.save(pastDueReservation);
+        // Act
+        scheduler.completePastDueConfirmedReservations();
+
+        Reservation updatedNormalReservation = reservationRepository.findById(bookedNormalReservation.getId()).orElseThrow();
+        Reservation updatedPastDueReservation = reservationRepository.findById(bookedPastDueReservation.getId()).orElseThrow();
+        // Assert
+        assertEquals(ReservationStatus.PENDING, updatedNormalReservation.getStatus());
+        assertEquals(ReservationStatus.COMPLETED, updatedPastDueReservation.getStatus());
+    }
+}


### PR DESCRIPTION
## Context

This PR introduces automated lifecycle management for our reservations via scheduled background jobs. We need to automatically free up locked inventory when users abandon their carts (stale `PENDING` status) and update the system when active rentals end (past-due `CONFIRMED` status). This ensures our database accurately reflects physical fleet availability without requiring manual admin intervention.

Closes #52 

## What Changed

- Added `ReservationLifecycleScheduler` with two background jobs:
  - A recurring job to cancel `PENDING` reservations older than 30 minutes.
  - A scheduled job to mark `CONFIRMED` rentals as `COMPLETED` when their `endDate` is in the past.
- Introduced a reusable `TestDataFactory` (`@TestComponent`) implementing the Object Mother pattern to cleanly generate `User`, `BikeModel`, and `BikeInstance` dependencies for our integration tests without muddying the Arrange phase.
- Parameterized the reservation creation in the test factory to explicitly link entities and prevent "Hidden Graph" data bugs.
- Wrote `ReservationSchedulerIntegrationTest` to verify the background jobs, utilizing `JdbcTemplate` to reliably time-travel `created_at` timestamps to test the stale pending logic while bypassing Hibernate's `@PrePersist` annotations.

## Testing

- [x] Unit tests written and passing
- [x] Application compiles and starts successfully

## Notes FOR the Reviewer

Please take a close look at the new `TestDataFactory` in the `src/test/java/.../factory` directory. It is designed to be highly reusable for our upcoming integration tests, so we don't duplicate boilerplate. Also, note the use of the `JdbcTemplate` backdoor in the tests to simulate historical `created_at` timestamps while completely dodging timezone offsets.