### PR TITLE
Feat/implement login endpoint jwt

### DIFF
--- a/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -191,6 +192,15 @@ public class GlobalExceptionHandler {
         );
         problem.setTitle("Invalid arguments");
         return problem;
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    public ProblemDetail handleBadCredentialsException(BadCredentialsException ex) {
+        log.warn("Invalid email or password: {}", ex.getMessage());
+        return ProblemDetail.forStatusAndDetail(
+                HttpStatus.UNAUTHORIZED,
+                "Invalid email or password."
+        );
     }
 
     /**

--- a/src/main/java/com/velocity/api/config/SecurityConfig.java
+++ b/src/main/java/com/velocity/api/config/SecurityConfig.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -35,7 +37,7 @@ public class SecurityConfig {
                 .sessionManagement(sessionManagement ->
                         sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(req -> req
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/register").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/register", "/api/v1/auth/login").permitAll()
                         .requestMatchers("/api/swagger-ui.html", "/api/swagger-ui/**", "/api/api-docs/**", "/v3/api-docs/**").permitAll()
                         .anyRequest().authenticated()
                 )
@@ -44,5 +46,10 @@ public class SecurityConfig {
         // Under the hood, Spring creates a concrete class
         // (DefaultSecurityFilterChain) that implements the interface
         // and returns it.
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) {
+        return config.getAuthenticationManager();
     }
 }

--- a/src/main/java/com/velocity/api/security/JwtService.java
+++ b/src/main/java/com/velocity/api/security/JwtService.java
@@ -7,11 +7,15 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.Map;
 
 @Service
 public class JwtService {
     @Value("${security.jwt.secret-key}")
     private String secretKey;
+    @Value("${security.jwt.expiration-ms}")
+    private long jwtExpiration;
 
     private SecretKey getSignInKey() {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
@@ -22,7 +26,26 @@ public class JwtService {
         return Jwts.parser().verifyWith(getSignInKey()).build().parseSignedClaims(token).getPayload().getSubject();
     }
 
+    public <T> T extractClaim(String token, String claimKey, Class<T> type) {
+        return Jwts.parser()
+                .verifyWith(getSignInKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get(claimKey, type);
+    }
+
     public boolean isTokenValid(String token, UserDetails userDetails) {
         return extractUsername(token).equals(userDetails.getUsername());
+    }
+
+    public String generateToken(Map<String, Object> extraClaims, UserDetails userDetails) {
+        return Jwts.builder()
+                .claims(extraClaims)
+                .subject(userDetails.getUsername())
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + jwtExpiration))
+                .signWith(getSignInKey())
+                .compact();
     }
 }

--- a/src/main/java/com/velocity/api/user/controller/AuthController.java
+++ b/src/main/java/com/velocity/api/user/controller/AuthController.java
@@ -1,10 +1,14 @@
 package com.velocity.api.user.controller;
 
+import com.velocity.api.user.dto.UserLoginRequest;
+import com.velocity.api.user.dto.UserLoginResponse;
 import com.velocity.api.user.dto.UserRegistrationRequest;
 import com.velocity.api.user.dto.UserRegistrationResponse;
+import com.velocity.api.user.service.AuthService;
 import com.velocity.api.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +23,7 @@ import java.net.URI;
 @RequiredArgsConstructor
 public class AuthController {
     private final UserService userService;
+    private final AuthService authService;
 
     @PostMapping("/register")
     public ResponseEntity<UserRegistrationResponse> registerUser(@Valid @RequestBody UserRegistrationRequest request) {
@@ -31,5 +36,11 @@ public class AuthController {
                 .toUri();
 
         return ResponseEntity.created(location).body(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<UserLoginResponse> loginUser(@Valid @RequestBody UserLoginRequest request) {
+        UserLoginResponse response = authService.login(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/velocity/api/user/dto/UserLoginRequest.java
+++ b/src/main/java/com/velocity/api/user/dto/UserLoginRequest.java
@@ -1,0 +1,14 @@
+package com.velocity.api.user.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Valid
+public record UserLoginRequest(
+        @NotBlank
+        @Email
+        String email,
+        @NotBlank
+        String password) {
+}

--- a/src/main/java/com/velocity/api/user/dto/UserLoginResponse.java
+++ b/src/main/java/com/velocity/api/user/dto/UserLoginResponse.java
@@ -1,0 +1,7 @@
+package com.velocity.api.user.dto;
+
+public record UserLoginResponse(
+        String accessToken,
+        String tokenType,
+        long expiresIn) {
+}

--- a/src/main/java/com/velocity/api/user/service/AuthService.java
+++ b/src/main/java/com/velocity/api/user/service/AuthService.java
@@ -1,0 +1,46 @@
+package com.velocity.api.user.service;
+
+import com.velocity.api.security.JwtService;
+import com.velocity.api.user.User;
+import com.velocity.api.user.dto.UserLoginRequest;
+import com.velocity.api.user.dto.UserLoginResponse;
+import com.velocity.api.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+    private final JwtService jwtService;
+
+    @Value("${security.jwt.expiration-ms}")
+    private long jwtExpiration;
+
+    public UserLoginResponse login(UserLoginRequest request) {
+        // password check
+        Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(request.email(), request.password()));
+        // gather extra claims
+        User user = userRepository.findByEmail(request.email());
+        HashMap<String, Object> extraClaims = new HashMap<>();
+        extraClaims.put("id", user.getId());
+        extraClaims.put("role", user.getRole());
+
+        // UserDetails userDetails = customUserDetailsService.loadUserByUsername(request.email());
+        // Cast the principal (the logged-in entity) to our Spring UserDetails object
+        UserDetails userDetails = (UserDetails) authentication.getPrincipal();
+
+        // call token generator
+        assert userDetails != null;
+        String generatedToken = jwtService.generateToken(extraClaims, userDetails);
+        return new UserLoginResponse(generatedToken, "Bearer", jwtExpiration);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,6 +24,7 @@ spring:
 security:
   jwt:
     secret-key: "404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970"
+    expiration-ms: 86400000 # 24h in ms
 
 springdoc:
   swagger-ui:

--- a/src/test/java/com/velocity/api/reservation/ReservationConcurrencyIntegrationTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationConcurrencyIntegrationTest.java
@@ -8,6 +8,9 @@ import com.velocity.api.bike.repository.BikeModelRepository;
 import com.velocity.api.reservation.dto.ReservationBookRequest;
 import com.velocity.api.reservation.repository.ReservationRepository;
 import com.velocity.api.common.City;
+import com.velocity.api.security.CustomUserDetailsService;
+import com.velocity.api.security.JwtService;
+import com.velocity.api.user.User;
 import com.velocity.api.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,12 +20,16 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.*;
@@ -46,8 +53,13 @@ public class ReservationConcurrencyIntegrationTest {
     private BikeInstanceRepository bikeInstanceRepository;
     @Autowired
     private ReservationRepository reservationRepository;
+    @Autowired
+    private JwtService jwtService;
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
 
     private UUID bikeInstanceId;
+    private String validToken;
 
     @BeforeEach
     public void setUp() {
@@ -60,6 +72,13 @@ public class ReservationConcurrencyIntegrationTest {
         BikeModel savedBikeModel = bikeModelRepository.save(BikeModel.create("Test", "Test", 100, 100, 50, BikeCategory.AGILITY));
         BikeInstance savedBikeInstance = bikeInstanceRepository.save(BikeInstance.initialize(savedBikeModel, City.GDANSK));
         bikeInstanceId = savedBikeInstance.getId();
+
+        User user = userRepository.findByEmail("test@test.com");
+        HashMap<String, Object> extraClaims = new HashMap<>();
+        extraClaims.put("id", user.getId());
+        extraClaims.put("role", user.getRole());
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername("test@test.com");
+        validToken = jwtService.generateToken(extraClaims, userDetails);
     }
 
     @AfterEach
@@ -70,7 +89,6 @@ public class ReservationConcurrencyIntegrationTest {
         userRepository.deleteAll();
     }
 
-    @Disabled("Blocked until Issue #22 provides JWT token generation")
     @Test
     public void createReservation_ConcurrentIdenticalRequests_ReturnsCreatedAndConflict() throws ExecutionException, InterruptedException {
         // prep the req
@@ -84,8 +102,16 @@ public class ReservationConcurrencyIntegrationTest {
         Callable<ResponseEntity<String>> bookingTask = () -> {
             // Freeze the thread until the main test thread drops the gate
             latch.await();
-            // Fire the POST request to the controller
-            return testRestTemplate.postForEntity("/api/v1/reservations", req, String.class);
+            // fire POST req with auth header via exchange
+            HttpHeaders headers = new HttpHeaders();
+            headers.setBearerAuth(validToken); // Spring's built-in method for "Bearer eyJ..."
+            HttpEntity<ReservationBookRequest> entity = new HttpEntity<>(req, headers);
+            return testRestTemplate.exchange(
+                    "/api/v1/reservations",
+                    HttpMethod.POST,
+                    entity,
+                    String.class
+            );
         };
 
         try {

--- a/src/test/java/com/velocity/api/security/AuthServiceTest.java
+++ b/src/test/java/com/velocity/api/security/AuthServiceTest.java
@@ -1,0 +1,82 @@
+package com.velocity.api.security;
+
+import com.velocity.api.common.City;
+import com.velocity.api.user.User;
+import com.velocity.api.user.dto.UserLoginRequest;
+import com.velocity.api.user.dto.UserLoginResponse;
+import com.velocity.api.user.repository.UserRepository;
+import com.velocity.api.user.service.AuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceTest {
+    @Mock
+    private AuthenticationManager authenticationManager;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private JwtService jwtService;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @BeforeEach
+    public void setUp() {
+        ReflectionTestUtils.setField(authService, "jwtExpiration", 86400000L);
+    }
+
+    @Test
+    public void login_validData_orchestratesDependenciesCorrectly() {
+        // Arrange
+        // Create a dummy Spring Security UserDetails (like in JwtServiceTest)
+        UserDetails dummyUserDetails = org.springframework.security.core.userdetails.User.builder()
+                .username("test@test.com")
+                .password("hash")
+                .build();
+        // Create a mock Authentication object
+        Authentication mockAuth = mock(Authentication.class);
+
+        // Tell the mock what to return
+        when(mockAuth.getPrincipal()).thenReturn(dummyUserDetails);
+
+        // Tell the AuthenticationManager to return your mockAuth!
+        when(authenticationManager.authenticate(any())).thenReturn(mockAuth);
+        when(userRepository.findByEmail(anyString())).thenReturn(User.registerClient("test@test.com", "hash", "Test", "+48000400000", City.GDANSK));
+        when(jwtService.generateToken(any(), any())).thenReturn("fake-jwt-string");
+        UserLoginRequest request = new UserLoginRequest("test@test.com", "hash");
+        // Act
+        UserLoginResponse userLoginResponse = authService.login(request);
+        // Assert
+        assertThat(userLoginResponse).hasFieldOrPropertyWithValue("accessToken", "fake-jwt-string");
+        assertThat(userLoginResponse).hasFieldOrPropertyWithValue("expiresIn", 86400000L);
+    }
+
+    @Test
+    public void login_invalidCredentials_throwsExceptionAndAborts() {
+        // Arrange
+        when(authenticationManager.authenticate(any())).thenThrow(new BadCredentialsException("Bad Credentials"));
+        UserLoginRequest request = new UserLoginRequest("test@test.com", "hash");
+        // Act & Assert
+        assertThrows(BadCredentialsException.class, () -> authService.login(request));
+
+        // Mockito's verify to assert zero interactions - database was never queried
+        verify(userRepository, never()).findByEmail(anyString());
+        verify(jwtService, never()).generateToken(any(), any());
+    }
+}

--- a/src/test/java/com/velocity/api/security/JwtServiceTest.java
+++ b/src/test/java/com/velocity/api/security/JwtServiceTest.java
@@ -1,0 +1,92 @@
+package com.velocity.api.security;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JwtServiceTest {
+    private JwtService jwtService;
+
+    @BeforeEach
+    public void setUp() {
+        jwtService = new JwtService();
+
+        ReflectionTestUtils.setField(jwtService, "secretKey", "404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970");
+        ReflectionTestUtils.setField(jwtService, "jwtExpiration", 86400000L);
+    }
+
+    // prove generated token contains exact data we asked it to store
+    @Test
+    public void generateToken_validArguments_containsCorrectData() {
+        // Arrange
+        UserDetails userDetails = User.builder()
+                .username("test@test.com")
+                .password("hash")
+                .build();
+        HashMap<String, Object> extraClaims = new HashMap<>();
+        String randomUUIDString = UUID.randomUUID().toString();
+        extraClaims.put("id", randomUUIDString);
+        extraClaims.put("role", "CLIENT");
+        // Act
+        String generatedToken = jwtService.generateToken(extraClaims, userDetails);
+        String username = jwtService.extractUsername(generatedToken);
+        String extractedId = jwtService.extractClaim(generatedToken, "id", String.class);
+        String extractedRole = jwtService.extractClaim(generatedToken, "role", String.class);
+
+        // Assert
+        assertThat(username).isEqualTo("test@test.com");
+        assertThat(extractedId).isEqualTo(randomUUIDString);
+        assertThat(extractedRole).isEqualTo("CLIENT");
+    }
+
+    @Test
+    public void generateToken_expiredToken_throwsExpiredJwtException() {
+        ReflectionTestUtils.setField(jwtService, "jwtExpiration", -1000L);
+
+        // Arrange
+        UserDetails userDetails = User.builder()
+                .username("test@test.com")
+                .password("hash")
+                .build();
+        HashMap<String, Object> extraClaims = new HashMap<>();
+        String randomUUIDString = UUID.randomUUID().toString();
+        extraClaims.put("id", randomUUIDString);
+        extraClaims.put("role", "CLIENT");
+        String generatedToken = jwtService.generateToken(extraClaims, userDetails);
+        // Act & Assert
+        assertThrows(ExpiredJwtException.class, () -> {
+            jwtService.extractUsername(generatedToken);
+        });
+    }
+
+    @Test
+    public void generateToken_signatureForgery_throwsSignatureException() {
+        // Arrange
+        UserDetails userDetails = User.builder()
+                .username("test@test.com")
+                .password("hash")
+                .build();
+        HashMap<String, Object> extraClaims = new HashMap<>();
+        String randomUUIDString = UUID.randomUUID().toString();
+        extraClaims.put("id", randomUUIDString);
+        extraClaims.put("role", "CLIENT");
+        String generatedToken = jwtService.generateToken(extraClaims, userDetails);
+
+        JwtService hackerService = new JwtService();
+        ReflectionTestUtils.setField(hackerService, "secretKey", "303E635266556A586E3272357538782F413F4428472B4B6250645367566B5970");
+        // Act & Assert
+        assertThrows(SignatureException.class, () -> {
+            hackerService.extractUsername(generatedToken);
+        });
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,4 +9,5 @@ spring:
 security:
   jwt:
     secret-key: "404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970"
+    expiration-ms: 86400000 # 24h in ms
 


### PR DESCRIPTION
## Context

To support the React frontend, we need a way for users to authenticate and receive a stateless credential. This PR introduces the JWT generation engine and the `/api/v1/auth/login` endpoint, allowing registered users to trade valid credentials for a signed token, unlocking the protected routes configured in #56 issue.

Closes #58 

## What Changed

- **Enriched Tokens:** Configured `JwtService` to inject the user's `UUID id` and `Role` directly into the token payload as custom claims. This allows the frontend to conditionally render UI elements without needing an immediate follow-up `/auth/me` request.
- **Service-Layer Orchestration:** Created `AuthService` to handle `AuthenticationManager` interactions, fetch domain claims, and generate the token, keeping `AuthController` strictly thin.
- **Anti-Enumeration Error Handling:** Added a `BadCredentialsException` handler in `GlobalExceptionHandler` that returns a generic `401 Unauthorized` ("Invalid email or password.") `ProblemDetail` to prevent malicious email enumeration.
- **Externalized Config:** Added `security.jwt.expiration-ms` to both `application.yaml` and `application-test.yaml` to prevent hardcoded time logic.
- **Fixed Technical Debt:** Re-enabled `ReservationConcurrencyIntegrationTest` by injecting a valid, dynamically generated JWT into the test's `TestRestTemplate` headers.

## Testing

- [x] Unit tests written and passing (`JwtServiceTest` for cryptographic verification/expiration/forgery and `AuthServiceTest` for business logic flow and DB isolation).
- [x] Application compiles and starts successfully