### PR TITLE
Feat/auth me and logout endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      redis:
+        image: redis:8.10.1-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,14 @@ services:
       - POSTGRES_PASSWORD=password
     volumes:
       - postgres-data:/var/lib/postgresql/data
+  redis:
+    image: redis:8.10.1-alpine
+    ports:
+      - "6379:6379"
+    container_name: velocity-redis
+    volumes:
+      - redis-data:/data
 
 volumes:
   postgres-data:
+  redis-data:

--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,10 @@
             <scope>runtime</scope>
             <version>0.12.6</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/velocity/api/bike/BikeModel.java
+++ b/src/main/java/com/velocity/api/bike/BikeModel.java
@@ -4,7 +4,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/com/velocity/api/bike/repository/BikeInstanceRepository.java
+++ b/src/main/java/com/velocity/api/bike/repository/BikeInstanceRepository.java
@@ -3,7 +3,6 @@ package com.velocity.api.bike.repository;
 import com.velocity.api.bike.BikeInstance;
 import com.velocity.api.bike.BikeStatus;
 import com.velocity.api.bike.repository.projection.AvailableModelProjection;
-import org.springframework.cglib.core.Local;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;

--- a/src/main/java/com/velocity/api/reservation/Reservation.java
+++ b/src/main/java/com/velocity/api/reservation/Reservation.java
@@ -7,7 +7,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;

--- a/src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java
@@ -21,11 +21,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, UUID> 
                             AND r.endDate > :startDate
                       )
             """)
-    public boolean isBikeAvailable(@Param("bikeId") UUID bikeId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+    boolean isBikeAvailable(@Param("bikeId") UUID bikeId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
     @Query("SELECT r.id FROM Reservation r WHERE r.status = :status AND r.createdAt < :cutoff")
-    public List<UUID> findStalePendingReservationsIds(@Param("status") ReservationStatus status, @Param("cutoff") Instant cutoff);
+    List<UUID> findStalePendingReservationsIds(@Param("status") ReservationStatus status, @Param("cutoff") Instant cutoff);
 
     @Query("SELECT r.id FROM Reservation r WHERE r.status = :status AND r.endDate < :today")
-    public List<UUID> findPastDueConfirmedReservationsIds(@Param("status") ReservationStatus status, @Param("today") LocalDate today);
+    List<UUID> findPastDueConfirmedReservationsIds(@Param("status") ReservationStatus status, @Param("today") LocalDate today);
 }

--- a/src/main/java/com/velocity/api/security/CustomUserDetailsService.java
+++ b/src/main/java/com/velocity/api/security/CustomUserDetailsService.java
@@ -16,10 +16,8 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public @NonNull UserDetails loadUserByUsername(@NonNull String username) {
-        User user = userRepository.findByEmail(username);
-        if (user == null) {
-            throw new UsernameNotFoundException("User does not exists.");
-        }
+        User user = userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User does not exists."));
         return org.springframework.security.core.userdetails.User.builder()
                 .username(user.getEmail())
                 .password(user.getPasswordHash())

--- a/src/main/java/com/velocity/api/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/velocity/api/security/JwtAuthenticationFilter.java
@@ -13,7 +13,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.web.authentication.WebAuthenticationDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -29,7 +28,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final TokenBlacklistRepository tokenBlacklistRepository;
 
     @Override
-    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
 
         String header = request.getHeader("Authorization");
         if (header == null || !header.startsWith("Bearer ")) {

--- a/src/main/java/com/velocity/api/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/velocity/api/security/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.velocity.api.security;
 
+import com.velocity.api.security.repository.TokenBlacklistRepository;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -12,6 +13,8 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -23,6 +26,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtService jwtService;
     private final UserDetailsService userDetailsService;
+    private final TokenBlacklistRepository tokenBlacklistRepository;
 
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -34,11 +38,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         try {
             String rawToken = header.substring(7);
+            if (tokenBlacklistRepository.isBlacklisted(rawToken)) {
+                log.warn("JWT token is blacklisted.");
+                filterChain.doFilter(request, response);
+                return;
+            }
             String username = jwtService.extractUsername(rawToken);
             if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
                 UserDetails userDetails = userDetailsService.loadUserByUsername(username);
                 if (jwtService.isTokenValid(rawToken, userDetails)) {
                     UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                     SecurityContextHolder.getContext().setAuthentication(authToken);
                 }
             }

--- a/src/main/java/com/velocity/api/security/JwtService.java
+++ b/src/main/java/com/velocity/api/security/JwtService.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
+import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
 
@@ -26,8 +27,8 @@ public class JwtService {
         return Jwts.parser().verifyWith(getSignInKey()).build().parseSignedClaims(token).getPayload().getSubject();
     }
 
-    public Date extractExpration(String token) {
-        return Jwts.parser().verifyWith(getSignInKey()).build().parseSignedClaims(token).getPayload().getExpiration();
+    public Instant extractExpiration(String token) {
+        return Jwts.parser().verifyWith(getSignInKey()).build().parseSignedClaims(token).getPayload().getExpiration().toInstant();
     }
 
     public <T> T extractClaim(String token, String claimKey, Class<T> type) {

--- a/src/main/java/com/velocity/api/security/JwtService.java
+++ b/src/main/java/com/velocity/api/security/JwtService.java
@@ -26,6 +26,10 @@ public class JwtService {
         return Jwts.parser().verifyWith(getSignInKey()).build().parseSignedClaims(token).getPayload().getSubject();
     }
 
+    public Date extractExpration(String token) {
+        return Jwts.parser().verifyWith(getSignInKey()).build().parseSignedClaims(token).getPayload().getExpiration();
+    }
+
     public <T> T extractClaim(String token, String claimKey, Class<T> type) {
         return Jwts.parser()
                 .verifyWith(getSignInKey())

--- a/src/main/java/com/velocity/api/security/repository/TokenBlacklistRepository.java
+++ b/src/main/java/com/velocity/api/security/repository/TokenBlacklistRepository.java
@@ -1,0 +1,23 @@
+package com.velocity.api.security.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class TokenBlacklistRepository {
+    private final StringRedisTemplate stringRedisTemplate;
+    private static final String KEY_PREFIX = "auth:blacklist:";
+
+    public void blacklist(String token, Duration ttl) {
+        if (ttl.isNegative() || ttl.isZero()) return;
+        stringRedisTemplate.opsForValue().set(KEY_PREFIX + token, "blacklisted", ttl);
+    }
+
+    public boolean isBlacklisted(String token) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(KEY_PREFIX + token));
+    }
+}

--- a/src/main/java/com/velocity/api/user/controller/AuthController.java
+++ b/src/main/java/com/velocity/api/user/controller/AuthController.java
@@ -1,15 +1,11 @@
 package com.velocity.api.user.controller;
 
-import com.velocity.api.user.dto.UserLoginRequest;
-import com.velocity.api.user.dto.UserLoginResponse;
-import com.velocity.api.user.dto.UserRegistrationRequest;
-import com.velocity.api.user.dto.UserRegistrationResponse;
+import com.velocity.api.user.dto.*;
 import com.velocity.api.user.service.AuthService;
 import com.velocity.api.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -49,5 +45,11 @@ public class AuthController {
             authService.logout(token);
         }
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserProfileResponse> getProfile() {
+        UserProfileResponse response = userService.getProfile();
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/velocity/api/user/controller/AuthController.java
+++ b/src/main/java/com/velocity/api/user/controller/AuthController.java
@@ -8,12 +8,10 @@ import com.velocity.api.user.service.AuthService;
 import com.velocity.api.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
@@ -42,5 +40,14 @@ public class AuthController {
     public ResponseEntity<UserLoginResponse> loginUser(@Valid @RequestBody UserLoginRequest request) {
         UserLoginResponse response = authService.login(request);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logoutUser(@RequestHeader(HttpHeaders.AUTHORIZATION) String authHeader) {
+        if (authHeader.startsWith("Bearer ")) {
+            String token = authHeader.substring(7);
+            authService.logout(token);
+        }
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/velocity/api/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/velocity/api/user/dto/UserProfileResponse.java
@@ -1,0 +1,18 @@
+package com.velocity.api.user.dto;
+
+import com.velocity.api.common.City;
+import com.velocity.api.user.UserRole;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+public record UserProfileResponse(
+        UUID id,
+        String email,
+        String fullName,
+        String phone,
+        UserRole role,
+        City city,
+        LocalDate joinedDate
+) {
+}

--- a/src/main/java/com/velocity/api/user/repository/UserRepository.java
+++ b/src/main/java/com/velocity/api/user/repository/UserRepository.java
@@ -3,9 +3,10 @@ package com.velocity.api.user.repository;
 import com.velocity.api.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
     boolean existsByEmail(String email);
-    User findByEmail(String email);
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/velocity/api/user/service/AuthService.java
+++ b/src/main/java/com/velocity/api/user/service/AuthService.java
@@ -5,18 +5,18 @@ import com.velocity.api.security.repository.TokenBlacklistRepository;
 import com.velocity.api.user.User;
 import com.velocity.api.user.dto.UserLoginRequest;
 import com.velocity.api.user.dto.UserLoginResponse;
-import com.velocity.api.user.dto.UserLogoutRequest;
 import com.velocity.api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
-import java.util.Date;
+import java.time.Instant;
 import java.util.HashMap;
 
 @Service
@@ -34,7 +34,7 @@ public class AuthService {
         // password check
         Authentication authentication = authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(request.email(), request.password()));
         // gather extra claims
-        User user = userRepository.findByEmail(request.email());
+        User user = userRepository.findByEmail(request.email()).orElseThrow(() -> new BadCredentialsException("Bad credentials"));
         HashMap<String, Object> extraClaims = new HashMap<>();
         extraClaims.put("id", user.getId());
         extraClaims.put("role", user.getRole());
@@ -50,8 +50,8 @@ public class AuthService {
     }
 
     public void logout(String token) {
-        Date expirationDate = jwtService.extractExpration(token);
-        Duration ttl = Duration.between(Date, expirationDate);
+        Instant expirationDate = jwtService.extractExpiration(token);
+        Duration ttl = Duration.between(Instant.now(), expirationDate);
         if (!ttl.isNegative() && !ttl.isZero()) tokenBlacklistRepository.blacklist(token, ttl);
     }
 }

--- a/src/main/java/com/velocity/api/user/service/AuthService.java
+++ b/src/main/java/com/velocity/api/user/service/AuthService.java
@@ -1,9 +1,11 @@
 package com.velocity.api.user.service;
 
 import com.velocity.api.security.JwtService;
+import com.velocity.api.security.repository.TokenBlacklistRepository;
 import com.velocity.api.user.User;
 import com.velocity.api.user.dto.UserLoginRequest;
 import com.velocity.api.user.dto.UserLoginResponse;
+import com.velocity.api.user.dto.UserLogoutRequest;
 import com.velocity.api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,6 +15,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
+import java.util.Date;
 import java.util.HashMap;
 
 @Service
@@ -21,6 +25,7 @@ public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final UserRepository userRepository;
     private final JwtService jwtService;
+    private final TokenBlacklistRepository tokenBlacklistRepository;
 
     @Value("${security.jwt.expiration-ms}")
     private long jwtExpiration;
@@ -42,5 +47,11 @@ public class AuthService {
         assert userDetails != null;
         String generatedToken = jwtService.generateToken(extraClaims, userDetails);
         return new UserLoginResponse(generatedToken, "Bearer", jwtExpiration);
+    }
+
+    public void logout(String token) {
+        Date expirationDate = jwtService.extractExpration(token);
+        Duration ttl = Duration.between(Date, expirationDate);
+        if (!ttl.isNegative() && !ttl.isZero()) tokenBlacklistRepository.blacklist(token, ttl);
     }
 }

--- a/src/main/java/com/velocity/api/user/service/UserService.java
+++ b/src/main/java/com/velocity/api/user/service/UserService.java
@@ -1,15 +1,21 @@
 package com.velocity.api.user.service;
 
 import com.velocity.api.common.exception.EmailAlreadyRegisteredException;
+import com.velocity.api.common.exception.ResourceNotFoundException;
 import com.velocity.api.user.User;
+import com.velocity.api.user.dto.UserProfileResponse;
 import com.velocity.api.user.dto.UserRegistrationRequest;
 import com.velocity.api.user.dto.UserRegistrationResponse;
 import com.velocity.api.user.repository.UserRepository;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -36,5 +42,14 @@ public class UserService {
                 registeredUser.getCity(),
                 registeredUser.getRole()
         );
+    }
+
+    public UserProfileResponse getProfile() {
+        UserDetails userDetails = (UserDetails) Objects.requireNonNull(SecurityContextHolder.getContext().getAuthentication()).getPrincipal();
+        assert userDetails != null;
+        String email = userDetails.getUsername();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found with email: " + email));
+        return new UserProfileResponse(user.getId(), user.getEmail(), user.getFullName(), user.getPhone(), user.getRole(), user.getCity(), user.getJoinedDate());
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -20,6 +20,9 @@ spring:
     web:
       pageable:
         max-page-size: 50
+    redis:
+      host: localhost
+      port: 6379
 
 security:
   jwt:

--- a/src/test/java/com/velocity/api/User/UserServiceTest.java
+++ b/src/test/java/com/velocity/api/User/UserServiceTest.java
@@ -1,0 +1,60 @@
+package com.velocity.api.User;
+
+import com.velocity.api.common.exception.ResourceNotFoundException;
+import com.velocity.api.user.repository.UserRepository;
+import com.velocity.api.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @DisplayName("Given a valid session but missing user, getProfile should throw exception")
+    @Test
+    public void getProfile_userDeleted_throwsException() {
+        // Arrange: Create mocks for the security context
+        SecurityContext securityContext = mock(SecurityContext.class);
+        Authentication authentication = mock(Authentication.class);
+        UserDetails userDetails = mock(UserDetails.class);
+
+        // Configure the mocks to return a specific email
+        String testEmail = "test@test.com";
+        when(userDetails.getUsername()).thenReturn(testEmail);
+        when(authentication.getPrincipal()).thenReturn(userDetails);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+
+        // Inject the mocked context into the static Spring Security holder
+        SecurityContextHolder.setContext(securityContext);
+
+        // Configure the repository to return an empty box
+        when(userRepository.findByEmail(testEmail)).thenReturn(Optional.empty());
+
+        // Act & Assert: Prove that the exception is thrown and halts execution
+        assertThatThrownBy(() -> userService.getProfile())
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining(testEmail);
+
+        // Cleanup: Clear the context so it does not pollute other tests
+        SecurityContextHolder.clearContext();
+    }
+}

--- a/src/test/java/com/velocity/api/reservation/ReservationConcurrencyIntegrationTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationConcurrencyIntegrationTest.java
@@ -14,7 +14,6 @@ import com.velocity.api.user.User;
 import com.velocity.api.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.TestRestTemplate;
@@ -22,9 +21,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.*;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -73,7 +70,7 @@ public class ReservationConcurrencyIntegrationTest {
         BikeInstance savedBikeInstance = bikeInstanceRepository.save(BikeInstance.initialize(savedBikeModel, City.GDANSK));
         bikeInstanceId = savedBikeInstance.getId();
 
-        User user = userRepository.findByEmail("test@test.com");
+        User user = userRepository.findByEmail("test@test.com").orElseThrow(() -> new BadCredentialsException("Bad credentials"));
         HashMap<String, Object> extraClaims = new HashMap<>();
         extraClaims.put("id", user.getId());
         extraClaims.put("role", user.getRole());

--- a/src/test/java/com/velocity/api/reservation/ReservationTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationTest.java
@@ -2,7 +2,6 @@ package com.velocity.api.reservation;
 
 import com.velocity.api.common.exception.InvalidStatusTransitionException;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.test.util.ReflectionTestUtils;

--- a/src/test/java/com/velocity/api/security/AuthServiceTest.java
+++ b/src/test/java/com/velocity/api/security/AuthServiceTest.java
@@ -1,6 +1,7 @@
 package com.velocity.api.security;
 
 import com.velocity.api.common.City;
+import com.velocity.api.security.repository.TokenBlacklistRepository;
 import com.velocity.api.user.User;
 import com.velocity.api.user.dto.UserLoginRequest;
 import com.velocity.api.user.dto.UserLoginResponse;
@@ -9,15 +10,19 @@ import com.velocity.api.user.service.AuthService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,6 +39,8 @@ public class AuthServiceTest {
     private UserRepository userRepository;
     @Mock
     private JwtService jwtService;
+    @Mock
+    private TokenBlacklistRepository tokenBlacklistRepository;
 
     @InjectMocks
     private AuthService authService;
@@ -80,5 +87,26 @@ public class AuthServiceTest {
         // Mockito's verify to assert zero interactions - database was never queried
         verify(userRepository, never()).findByEmail(anyString());
         verify(jwtService, never()).generateToken(any(), any());
+    }
+
+    @Test
+    public void logout_validToken_savesToBlacklist() {
+        // Arrange
+        when(jwtService.extractExpiration(anyString())).thenReturn(Instant.now().plusSeconds(3600));
+        authService.logout("fake-token-123");
+        ArgumentCaptor<Duration> captor = ArgumentCaptor.forClass(Duration.class);
+        verify(tokenBlacklistRepository).blacklist(eq("fake-token-123"), captor.capture());
+        Duration capturedTtl = captor.getValue();
+        assertThat(capturedTtl).isBetween(Duration.ofSeconds(3590), Duration.ofSeconds(3600));
+    }
+
+    @Test
+    public void logout_expiredToken_doesNotCallRepository() {
+        // Arrange
+        when(jwtService.extractExpiration(anyString())).thenReturn(Instant.now().minusMillis(3600));
+        // Act
+        authService.logout("fake-token-123");
+        // Assert
+        verifyNoInteractions(tokenBlacklistRepository);
     }
 }

--- a/src/test/java/com/velocity/api/security/AuthServiceTest.java
+++ b/src/test/java/com/velocity/api/security/AuthServiceTest.java
@@ -18,6 +18,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,7 +59,7 @@ public class AuthServiceTest {
 
         // Tell the AuthenticationManager to return your mockAuth!
         when(authenticationManager.authenticate(any())).thenReturn(mockAuth);
-        when(userRepository.findByEmail(anyString())).thenReturn(User.registerClient("test@test.com", "hash", "Test", "+48000400000", City.GDANSK));
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(User.registerClient("test@test.com", "hash", "Test", "+48000400000", City.GDANSK)));
         when(jwtService.generateToken(any(), any())).thenReturn("fake-jwt-string");
         UserLoginRequest request = new UserLoginRequest("test@test.com", "hash");
         // Act

--- a/src/test/java/com/velocity/api/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/velocity/api/security/JwtAuthenticationFilterTest.java
@@ -1,0 +1,50 @@
+package com.velocity.api.security;
+
+
+import com.velocity.api.security.repository.TokenBlacklistRepository;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class JwtAuthenticationFilterTest {
+    @Mock
+    private TokenBlacklistRepository tokenBlacklistRepository;
+    @Mock
+    private UserDetailsService userDetailsService;
+
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Test
+    public void jwtAuthenticationFilterChain_blacklistedToken_requestRejected() throws ServletException, IOException {
+        when(tokenBlacklistRepository.isBlacklisted(anyString())).thenReturn(true);
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer fake-token-123");
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain filterChain = mock(FilterChain.class);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        // proves doFilter was called
+        verify(filterChain).doFilter(request, response);
+        verifyNoInteractions(userDetailsService);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -5,6 +5,10 @@ spring:
     password: password
   liquibase:
     contexts: test
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
 security:
   jwt:


### PR DESCRIPTION
## Context
Implements the `/auth/me` and `/auth/logout` endpoints to allow clients to fetch the authenticated user's profile and securely invalidate JWTs.

Closes #60 

## What Changed
- Created `TokenBlacklistRepository` backed by Redis to store revoked tokens with a TTL matching their remaining lifespan.
- Updated `JwtAuthenticationFilter` to intercept requests and reject blacklisted tokens before querying the database.
- Implemented `AuthService.logout()` to extract token expiration and persist it to the blacklist.
- Implemented `UserService.getProfile()` to safely unwrap the `SecurityContext` principal and map it to a secure `UserProfileResponse`.

## Testing
- [x] Unit tests written and passing
- [x] Application compiles and starts successfully

## Notes FOR the Reviewer
The Redis blacklist check is placed at the very top of the filter chain to act as a database shield against revoked tokens.