### PR TITLE
feat: add testcontainers for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,32 +8,6 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: admin
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: velocity_test
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      redis:
-        image: redis:8.10.1-alpine
-        ports:
-          - 6379:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,21 @@
             <artifactId>jackson-databind-nullable</artifactId>
             <version>0.2.11</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers-postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/com/velocity/api/BaseIntegrationTest.java
+++ b/src/test/java/com/velocity/api/BaseIntegrationTest.java
@@ -1,0 +1,17 @@
+package com.velocity.api;
+
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+@Testcontainers
+public abstract class BaseIntegrationTest {
+    @ServiceConnection
+    @Container
+    static PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:16-alpine");
+    @ServiceConnection(name = "redis")
+    @Container
+    static GenericContainer<?> redis = new GenericContainer<>("redis:8.10.1-alpine").withExposedPorts(6379);
+}

--- a/src/test/java/com/velocity/api/VelocityApiApplicationTests.java
+++ b/src/test/java/com/velocity/api/VelocityApiApplicationTests.java
@@ -6,10 +6,10 @@ import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
 @ActiveProfiles("test")
-class VelocityApiApplicationTests {
+class VelocityApiApplicationTests extends BaseIntegrationTest {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/src/test/java/com/velocity/api/reservation/ReservationConcurrencyIntegrationTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationConcurrencyIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.velocity.api.reservation;
 
+import com.velocity.api.BaseIntegrationTest;
 import com.velocity.api.bike.BikeCategory;
 import com.velocity.api.bike.BikeInstance;
 import com.velocity.api.bike.BikeModel;
@@ -37,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("test")
 @AutoConfigureTestRestTemplate
-public class ReservationConcurrencyIntegrationTest {
+public class ReservationConcurrencyIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
     @Autowired

--- a/src/test/java/com/velocity/api/reservation/scheduler/ReservationSchedulerIntegrationTest.java
+++ b/src/test/java/com/velocity/api/reservation/scheduler/ReservationSchedulerIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.velocity.api.reservation.scheduler;
 
+import com.velocity.api.BaseIntegrationTest;
 import com.velocity.api.bike.BikeInstance;
 import com.velocity.api.bike.repository.BikeInstanceRepository;
 import com.velocity.api.bike.repository.BikeModelRepository;
@@ -27,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest
 @ActiveProfiles("test")
 @Import(TestDataFactory.class) // This explicitly pulls the factory into the test context
-public class ReservationSchedulerIntegrationTest {
+public class ReservationSchedulerIntegrationTest extends BaseIntegrationTest {
     @Autowired
     private ReservationLifecycleScheduler scheduler;
     @Autowired

--- a/src/test/java/com/velocity/api/security/AuthenticationIntegrationTest.java
+++ b/src/test/java/com/velocity/api/security/AuthenticationIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.velocity.api.security;
 
+import com.velocity.api.BaseIntegrationTest;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -24,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL) // Tells JUnit to let Spring inject
 @RequiredArgsConstructor // creates constructor
 @ActiveProfiles("test")
-public class AuthenticationIntegrationTest {
+public class AuthenticationIntegrationTest extends BaseIntegrationTest {
 
     private final MockMvc mockMvc;
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,17 +1,8 @@
 spring:
-  datasource:
-    url: jdbc:postgresql://localhost:5432/velocity_test
-    username: admin
-    password: password
   liquibase:
     contexts: test
-  data:
-    redis:
-      host: localhost
-      port: 6379
 
 security:
   jwt:
     secret-key: "404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970"
     expiration-ms: 86400000 # 24h in ms
-


### PR DESCRIPTION
## Context

To safely verify our production database constraints (specifically ADR-001's `btree_gist` exclusion constraint) and our JWT blacklisting, our integration tests need to run against real PostgreSQL and Redis instances. This PR introduces Testcontainers to give us ephemeral, production-accurate infrastructure for our test suite and CI pipeline.

Closes #68 

## What Changed

- **Dependencies:** Added `spring-boot-testcontainers` and `org.testcontainers:postgresql` to `pom.xml` (test scope).
- **Test Infrastructure:** Created a shared `BaseIntegrationTest` utilizing Spring Boot 3's `@ServiceConnection` to spin up a `PostgreSQLContainer` (postgres:16-alpine) and a `GenericContainer` (redis:8.10.1-alpine).
- **Test Refactoring:** Updated `ReservationConcurrencyIntegrationTest`, `AuthenticationIntegrationTest`, and the default context load test to extend `BaseIntegrationTest`. 
- **Configuration Cleanup:** Removed hardcoded local database and Redis credentials from `application-test.yaml`.
- **CI Pipeline:** Removed the obsolete static `services:` block from `.github/workflows/ci.yml`. Testcontainers now securely orchestrates the containers directly on the GitHub Actions runner.

## Testing

- [x] Unit tests written and passing
- [x] Application compiles and starts successfully
- [x] `mvn clean test` passes locally without static containers running

## Notes FOR the Reviewer

The initial test context load will now take ~3-5 seconds longer as Docker pulls and spins up the PostgreSQL and Redis images. However, because we are using a shared `BaseIntegrationTest`, this startup penalty only occurs *once* per test suite run. 