### PR TITLE
feat: add reservation endpoint within mvc layers & update PROJECT_CON…

### DIFF
--- a/docs/context/PROJECT_CONTEXT.md
+++ b/docs/context/PROJECT_CONTEXT.md
@@ -1,13 +1,13 @@
-﻿# VeloCity Fleet API - AI Context
+# VeloCity Fleet API - AI Context
 
-Last updated: 2026-08-25
+Last updated: 2026-08-30
 
 > Single source of truth for AI assistants and contributors.
 > Keep this file aligned with the actual codebase, application configuration, security setup, and current implementation status.
 
 ## 1. Purpose
 
-This project is a Spring Boot backend for an e-bike rental platform. The primary engineering constraints are reservation integrity, exact financial calculations, clear API boundaries, and authenticated user actions. The current codebase is not a greenfield scaffold; it contains a working reservation flow, JWT-based auth, and scheduled lifecycle automation, while still exposing a few temporary implementation shortcuts.
+This project is a Spring Boot backend for an e-bike rental platform. The current implementation emphasizes reservation integrity, authenticated user operations, and explicit lifecycle state transitions for users and reservations. The codebase is beyond initial scaffolding and includes working auth, reservation booking, user self-service, admin user lifecycle operations, and scheduler-driven reservation maintenance.
 
 ## 2. Current stack
 
@@ -15,213 +15,242 @@ This project is a Spring Boot backend for an e-bike rental platform. The primary
 - Spring Boot 4.1.0
 - Spring Web MVC
 - Spring Data JPA / Hibernate
-- PostgreSQL 16
-- Redis 7 for JWT blacklist storage
+- PostgreSQL
+- Redis for JWT blacklist storage
 - Liquibase
 - Spring Security + JWT (JJWT)
 - Springdoc OpenAPI / Swagger UI
 - Maven
-- JUnit 5 + Mockito + Spring test support
-- Docker Compose for local infrastructure
+- JUnit 5 + Spring test support + Testcontainers
 
 Important notes:
-- The app expects PostgreSQL and Redis to be running locally on localhost:5432 and localhost:6379.
-- ddl-auto is intentionally set to validate; schema changes are Liquibase-managed.
-- There is no MapStruct setup. Mapping is currently handwritten in BikeInstanceMapper.
+- Runtime expects PostgreSQL and Redis on localhost:5432 and localhost:6379 by default.
+- `spring.jpa.hibernate.ddl-auto=validate`; schema evolution is Liquibase-managed.
+- Security is stateless and enforced through a JWT filter plus method-level authorization.
+- Pricing uses configured `pricing.daily-rate` (currently `50.00`) and BigDecimal-based calculation.
 
 ## 3. Current package layout and architecture
 
 Core packages:
-- com.velocity.api.user — user model, DTOs, auth endpoints, and profile management
-- com.velocity.api.bike — bike domain model, fleet endpoints, and service
-- com.velocity.api.reservation — reservation domain, controller, service, and scheduler
-- com.velocity.api.security — JWT, filters, custom user details, and blacklist repository
-- com.velocity.api.billing — pricing rules
-- com.velocity.api.common — shared DTOs, exceptions, and global error handling
-- com.velocity.api.config — Spring Security and OpenAPI config
+- `com.velocity.api.auth` — registration, login, logout, and current-user profile retrieval
+- `com.velocity.api.user` — user domain model, profile updates, and admin user lifecycle operations
+- `com.velocity.api.bike` — bike model/instance domain, availability projections, and fleet listing
+- `com.velocity.api.reservation` — reservation domain, booking, listing, and lifecycle scheduler
+- `com.velocity.api.security` — JWT service/filter, custom principal details, and Redis token blacklist repository
+- `com.velocity.api.pricing` — rental cost calculation
+- `com.velocity.api.common` — shared DTOs, enums, exception hierarchy, and global error mapping
+- `com.velocity.api.config` — security and infrastructure config
 
 Architecture rules currently visible in code:
-- Controllers speak HTTP and DTOs only; business logic stays in services.
-- Entities are persisted JPA models and do not expose public setters for most domain mutation.
-- Money is handled with BigDecimal.
-- Reservation overlap protection is implemented both in application logic and in the database layer.
-- ProblemDetail is the standard error envelope via GlobalExceptionHandler.
-- Security is stateless; JWTs are validated in a OncePerRequestFilter.
+- Controllers are thin HTTP adapters and delegate business logic to services.
+- Domain entities encapsulate state transitions and avoid broad public mutation.
+- Reservation availability is protected at both service and database layers.
+- Global error handling standardizes responses via RFC7807 `ProblemDetail`.
+- Method security (`@PreAuthorize`) is active and used for user ownership and admin-only routes.
 
 ## 4. Domain model (current code)
 
 ### User
 
 Fields:
-- id, email, passwordHash, fullName, phone, status, role, city, joinedDate
+- `id`, `email`, `passwordHash`, `fullName`, `phone`, `status`, `role`, `city`, `joinedDate`
 
 Rules in current code:
-- email and phone are unique.
-- joinedDate is set in @PrePersist.
-- Registration uses User.registerClient(...) and stores a BCrypt hash.
-- User.updateProfile(...) validates full name, phone, and city.
-- UserStatus is currently ACTIVE, and the role is CLIENT by default.
+- `email` and `phone` are unique.
+- `joinedDate` is assigned in `@PrePersist`.
+- Registration uses `User.registerClient(...)` with BCrypt-hashed password.
+- Profile updates are validated in `User.updateProfile(...)`.
+- Domain lifecycle methods exist: `block()`, `unblock()`, `softDelete()`.
+- Invalid user state changes throw `InvalidUserStateException`.
 
 ### BikeModel
 
 Fields:
-- id, name, description, speed, range, capacity, category
+- `id`, `name`, `description`, `speed`, `range`, `capacity`, `category`
 
 Rules in current code:
-- name is unique.
-- This is the abstract model or specification for a bike line.
+- `name` is unique.
+- Created through `BikeModel.create(...)`.
 
 ### BikeInstance
 
 Fields:
-- id, status, city, bikeModel
+- `id`, `status`, `city`, `bikeModel`
 
 Status values:
-- ACTIVE, MAINTENANCE, LOST, RETIRED
+- `ACTIVE`, `MAINTENANCE`, `LOST`, `RETIRED`
 
 Rules in current code:
-- A bike is created with BikeInstance.initialize(model, city).
-- Current availability logic treats only ACTIVE bikes as bookable.
-- The hardware state is checked in reservation creation before database insert.
+- Created through `BikeInstance.initialize(...)`.
+- Defaults to `ACTIVE`.
+- Reservation booking allows only `ACTIVE` instances.
 
 ### Reservation
 
 Fields:
-- id, startDate, endDate, totalCost, status, createdAt, version, user, bikeInstance
+- `id`, `startDate`, `endDate`, `totalCost`, `status`, `createdAt`, `version`, `user`, `bikeInstance`
 
 Status values:
-- PENDING, CONFIRMED, COMPLETED, CANCELLED
+- `PENDING`, `CONFIRMED`, `COMPLETED`, `CANCELLED`
 
 Rules in current code:
-- totalCost is stored as a persisted snapshot.
-- createdAt is assigned in @PrePersist.
-- @Version is present for optimistic locking on updates.
-- Valid transitions are enforced in Reservation.transitionTo(...):
-  - PENDING -> CONFIRMED
-  - PENDING -> CANCELLED
-  - CONFIRMED -> COMPLETED
-  - CONFIRMED -> CANCELLED
-- Invalid transitions throw InvalidStatusTransitionException.
+- Created through `Reservation.book(...)`.
+- `createdAt` is assigned in `@PrePersist`.
+- `@Version` enables optimistic locking.
+- Valid transitions in `Reservation.transitionTo(...)`:
+  - `PENDING -> CONFIRMED`
+  - `PENDING -> CANCELLED`
+  - `CONFIRMED -> COMPLETED`
+  - `CONFIRMED -> CANCELLED`
+- Invalid transitions throw `InvalidStatusTransitionException`.
 
 ## 5. Security and authentication
 
-The app currently has a real JWT-based auth layer.
+The application has a fully wired JWT-based auth layer.
 
 Current security setup:
-- SecurityConfig enables stateless sessions and a JWT filter.
-- JwtAuthenticationFilter reads the Authorization header and sets an authenticated principal if the token is valid and not blacklisted.
-- CustomUserDetailsService loads the user by email.
-- CustomUserDetails includes the user UUID as id, which is used in @PreAuthorize checks.
-- JwtService creates and validates signed JWTs with JJWT.
-- AuthService issues JWTs on login, with extra claims id and role.
-- TokenBlacklistRepository stores blacklisted tokens in Redis with a TTL.
-- BCryptPasswordEncoder is used for hashing.
+- `SecurityConfig` uses stateless session policy and installs `JwtAuthenticationFilter`.
+- `JwtAuthenticationFilter` parses bearer token, rejects blacklisted tokens, validates JWT, and populates security context.
+- `AuthService` authenticates credentials through `AuthenticationManager`.
+- JWT claims include user `id` and `role`.
+- Redis-backed blacklist is implemented in `com.velocity.api.security.repository.TokenBlacklistRepository`.
+- Password hashing uses `BCryptPasswordEncoder`.
+- Method-level security is enabled (`@EnableMethodSecurity`).
 
 Public endpoints currently:
-- POST /api/v1/auth/register
-- POST /api/v1/auth/login
-- Swagger and OpenAPI endpoints under /api/swagger-ui/** and /api/api-docs/**
+- `POST /api/v1/auth/register`
+- `POST /api/v1/auth/login`
+- Swagger/OpenAPI: `/api/swagger-ui.html`, `/api/swagger-ui/**`, `/api/api-docs/**`, `/v3/api-docs/**`
 
-Authenticated endpoints currently:
-- POST /api/v1/auth/logout
-- GET /api/v1/auth/me
-- PATCH /api/v1/users/{id}
-- POST /api/v1/reservations
-- GET /api/v1/reservations/availability
-- GET /api/v1/fleet
+Authenticated endpoints currently include:
+- `POST /api/v1/auth/logout`
+- `GET /api/v1/auth/me`
+- `PATCH /api/v1/users/{id}`
+- `GET /api/v1/fleet`
+- `POST /api/v1/reservations`
+- `GET /api/v1/reservations/availability`
+- `GET /api/v1/reservations/my`
+- `GET /api/v1/admin/users`
+- `POST /api/v1/admin/users/{id}/block`
+- `POST /api/v1/admin/users/{id}/unblock`
+- `POST /api/v1/admin/users/{id}/delete`
 
-Important implementation note:
-- ReservationController.book(...) currently hardcodes the authenticated user UUID to 00000000-0000-0000-0000-000000000001 instead of resolving the real principal from Spring Security.
-- This is a temporary in-code shortcut rather than a finished auth integration and should be treated as a known implementation detail while working in the codebase.
+Authorization notes:
+- User self-update is protected by `@PreAuthorize("#id == authentication.principal.id")`.
+- Admin routes are protected by class-level `@PreAuthorize("hasRole('ADMIN')")`.
+- Reservation booking and `/my` reservations resolve user ID from `@AuthenticationPrincipal CustomUserDetails` (no hardcoded ID path).
 
 ## 6. Current API surface
 
 ### Auth
-- POST /api/v1/auth/register — register a new client account
-- POST /api/v1/auth/login — authenticate and return a JWT
-- POST /api/v1/auth/logout — blacklist the bearer token in Redis
-- GET /api/v1/auth/me — fetch the current authenticated user profile
+- `POST /api/v1/auth/register` — register a new client account
+- `POST /api/v1/auth/login` — authenticate and return bearer token payload
+- `POST /api/v1/auth/logout` — blacklist bearer token until JWT expiration
+- `GET /api/v1/auth/me` — fetch current authenticated user profile
 
 ### Users
-- PATCH /api/v1/users/{id} — update a user profile; protected by @PreAuthorize("#id == authentication.principal.id")
+- `PATCH /api/v1/users/{id}` — update own profile (ownership enforced with `@PreAuthorize`)
+- `GET /api/v1/admin/users` — list users (admin only, paginated)
+- `POST /api/v1/admin/users/{id}/block` — block user (admin only)
+- `POST /api/v1/admin/users/{id}/unblock` — unblock user (admin only)
+- `POST /api/v1/admin/users/{id}/delete` — soft-delete user (admin only)
 
 ### Fleet
-- GET /api/v1/fleet — paginated list of active bikes (BikeStatus.ACTIVE)
+- `GET /api/v1/fleet` — paginated list of active bikes
 
 ### Reservations
-- POST /api/v1/reservations — book a bike for a date range
-- GET /api/v1/reservations/availability — list available model options for a date range
+- `POST /api/v1/reservations` — create reservation for authenticated user
+- `GET /api/v1/reservations/availability` — get available models for date range
+- `GET /api/v1/reservations/my` — get authenticated user reservations (paginated)
 
 ## 7. Reservation logic and booking guarantees
 
-The booking logic is intentionally strong:
-- ReservationService.book(...) validates the bike is ACTIVE.
-- It checks reservationRepository.isBikeAvailable(...) before save.
-- It computes totalCost with RentalCostCalculator based on a BigDecimal daily rate.
-- It persists a reservation with status PENDING.
-- The database layer adds a PostgreSQL exclusion constraint to prevent active reservation overlaps.
+Current booking workflow in `ReservationService.book(...)`:
+- Loads authenticated user and target bike instance.
+- Rejects non-`ACTIVE` bikes (`InvalidBikeStateException`).
+- Checks overlap with `reservationRepository.isBikeAvailable(...)`.
+- Calculates cost with `RentalCostCalculator` based on day count and configured daily rate.
+- Persists reservation with initial `PENDING` status.
 
-This means the app is trying to satisfy the hard guarantee: the booking cannot double-book a bike at the database level, even if the app-level check happens concurrently.
+Data consistency model:
+- Application-layer overlap check provides fast domain-level rejection.
+- Database-level protections (including overlap constraint from ADR direction) prevent race-condition double-booking under concurrency.
+- Reservation listing for current user uses repository paging with entity graph loading of bike and model relations.
 
 ## 8. Lifecycle automation and scheduled jobs
 
-The app includes a reservation lifecycle scheduler:
-- ReservationLifecycleScheduler runs on a fixed interval (@Scheduled(fixedRate = 10000) in current code) for test or dev convenience.
-- It cancels stale pending reservations older than 30 minutes.
-- It completes past-due confirmed reservations once their end date has passed.
+`ReservationLifecycleScheduler` is active and currently test/dev-tuned:
+- `@Scheduled(fixedRate = 10000)` cancel job: finds stale `PENDING` reservations older than 30 minutes and transitions to `CANCELLED`.
+- `@Scheduled(fixedRate = 10000)` complete job: finds past-due `CONFIRMED` reservations and transitions to `COMPLETED`.
+- Scheduler catches optimistic locking races to avoid crashing the job loop.
 
-This is active code, but the schedule is not final production timing; it is currently a short-interval job for testing and validation.
+Note:
+- The 10-second cadence is explicitly temporary/test-oriented (production-style schedules are present as commented intent).
 
 ## 9. Error handling and validation
 
-GlobalExceptionHandler covers:
-- validation failures (MethodArgumentNotValidException -> 400)
-- missing resources (ResourceNotFoundException, NoResourceFoundException -> 404)
-- duplicate email conflict (EmailAlreadyRegisteredException -> 409)
-- database integrity and overlap conflicts (DataIntegrityViolationException, CannotAcquireLockException -> 409)
-- invalid reservation transitions (InvalidStatusTransitionException -> 422)
-- invalid bike state (InvalidBikeStateException -> 422)
-- bad credentials (BadCredentialsException -> 401)
-- forbidden actions (AuthorizationDeniedException -> 403)
-- generic server errors -> 500
+`GlobalExceptionHandler` maps known failures to `ProblemDetail`:
+- validation errors (`MethodArgumentNotValidException`) -> 400 with `invalidFields`
+- missing resources (`ResourceNotFoundException`, `NoResourceFoundException`) -> 404
+- duplicate registration email (`EmailAlreadyRegisteredException`) -> 409
+- bike availability/business conflicts (`BikeNotAvailableException`) -> 409
+- data integrity/locking conflicts (`DataIntegrityViolationException`, `CannotAcquireLockException`) -> 409
+- invalid state transitions (`InvalidStatusTransitionException`, `InvalidUserStateException`) -> 422
+- invalid bike state (`InvalidBikeStateException`) -> 422
+- invalid credentials (`BadCredentialsException`) -> 401
+- forbidden actions (`AuthorizationDeniedException`) -> 403
+- unsupported HTTP method (`HttpRequestMethodNotSupportedException`) -> 405
+- fallback unexpected errors -> 500
 
-The app uses RFC7807 ProblemDetail responses rather than raw exceptions.
+Validation strategy:
+- Request DTO validation (`@Valid`) at controller boundaries.
+- Additional domain-level validation inside entity methods and services.
 
 ## 10. Database and migration model
 
-Current database conventions in code:
-- spring.jpa.hibernate.ddl-auto=validate
+Current database conventions:
+- PostgreSQL is the runtime relational database.
 - Liquibase is the schema source of truth.
-- PostgreSQL-specific overlap handling is part of the schema or changelog rather than a JPA-only concern.
-- @Version is present to protect update races but is not the main overlap protection mechanism.
+- Hibernate runs in validation mode (`ddl-auto=validate`) and does not auto-mutate schema.
+- Reservation entity optimistic locking (`@Version`) is active.
+- Reservation overlap protection is designed as both application check and database-enforced constraint.
 
 ## 11. Current implementation status and known gaps
 
-This app is more advanced than the older planning notes, but it still has obvious gaps:
-- JWT auth is implemented and wired into Spring Security.
-- Registration, login, logout, and profile retrieval are present.
-- Reservation booking and availability checks are implemented.
-- Reservation scheduling automation is in place.
-- Fleet listing is implemented for ACTIVE bikes and paginated responses.
-- Admin fleet management, richer role management, and a full production-grade user or admin lifecycle are not yet implemented.
-- The booking action still depends on a hardcoded user ID in ReservationController instead of resolving the authenticated principal.
-- The current scheduler cadence is intentionally short for testing and is not a final production schedule.
+Implemented:
+- JWT auth flow (register/login/logout/me) with Redis blacklist.
+- User self-profile updates.
+- Admin user lifecycle endpoints (list/block/unblock/soft-delete).
+- Fleet active-bike listing with pagination.
+- Reservation booking, availability query, and authenticated user reservation list (`/my`).
+- Scheduled stale-cancel and past-due-complete reservation transitions.
+
+Known gaps and risks:
+- Scheduler frequencies are test/dev-oriented and not yet production-tuned.
+- Security/CORS origins are currently local frontend focused (`localhost:5173`, `localhost:3000`).
+- Build tooling currently targets very new stack coordinates (Java 25 + Spring Boot 4.1.0), which may require environment alignment in IDE/CI.
 
 ## 12. Reference files
 
-- Runtime configuration: src/main/resources/application.yaml
-- Spring Security config: src/main/java/com/velocity/api/config/SecurityConfig.java
-- Auth controller: src/main/java/com/velocity/api/user/controller/AuthController.java
-- User profile controller: src/main/java/com/velocity/api/user/controller/UserController.java
-- Fleet controller: src/main/java/com/velocity/api/bike/controller/FleetController.java
-- Reservation controller: src/main/java/com/velocity/api/reservation/controller/ReservationController.java
-- Reservation service: src/main/java/com/velocity/api/reservation/service/ReservationService.java
-- Reservation entity: src/main/java/com/velocity/api/reservation/Reservation.java
-- User entity: src/main/java/com/velocity/api/user/User.java
-- Bike entity: src/main/java/com/velocity/api/bike/BikeInstance.java
-- Global exception handler: src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
-- Reservation scheduler: src/main/java/com/velocity/api/reservation/scheduler/ReservationLifecycleScheduler.java
+- Runtime configuration: `src/main/resources/application.yaml`
+- Build and dependencies: `pom.xml`
+- Security config: `src/main/java/com/velocity/api/config/SecurityConfig.java`
+- Auth controller: `src/main/java/com/velocity/api/auth/controller/AuthController.java`
+- Auth service: `src/main/java/com/velocity/api/auth/service/AuthService.java`
+- User controller: `src/main/java/com/velocity/api/user/controller/UserController.java`
+- Admin controller: `src/main/java/com/velocity/api/user/controller/AdminUserController.java`
+- Fleet controller: `src/main/java/com/velocity/api/bike/controller/FleetController.java`
+- Reservation controller: `src/main/java/com/velocity/api/reservation/controller/ReservationController.java`
+- Reservation service: `src/main/java/com/velocity/api/reservation/service/ReservationService.java`
+- Reservation repository: `src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java`
+- Reservation scheduler: `src/main/java/com/velocity/api/reservation/scheduler/ReservationLifecycleScheduler.java`
+- Reservation entity: `src/main/java/com/velocity/api/reservation/Reservation.java`
+- User entity: `src/main/java/com/velocity/api/user/User.java`
+- Bike instance entity: `src/main/java/com/velocity/api/bike/BikeInstance.java`
+- Global exception handler: `src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java`
+- JWT filter: `src/main/java/com/velocity/api/security/JwtAuthenticationFilter.java`
+- Token blacklist repository: `src/main/java/com/velocity/api/security/repository/TokenBlacklistRepository.java`
 
 ## 13. Planning note
 
-This file reflects the actual current state of the repository as of 2026-08-25. If the application evolves, update this document together with the code so AI agents and contributors work from a single accurate source of truth.
+This file reflects the repository state as of 2026-08-30. Update it together with meaningful architectural, API, security, or workflow changes so assistants and contributors remain grounded in current reality.

--- a/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
+++ b/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
@@ -1,12 +1,16 @@
 package com.velocity.api.reservation.controller;
 
+import com.velocity.api.common.dto.PaginatedResponse;
 import com.velocity.api.reservation.dto.AvailableModelResponse;
 import com.velocity.api.reservation.dto.ReservationBookRequest;
 import com.velocity.api.reservation.dto.ReservationBookResponse;
+import com.velocity.api.reservation.dto.ReservationResponse;
 import com.velocity.api.reservation.service.ReservationService;
 import com.velocity.api.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -38,6 +42,14 @@ public class ReservationController {
     @GetMapping("/availability")
     public ResponseEntity<List<AvailableModelResponse>> getAvailableModels(@RequestParam LocalDate startDate, @RequestParam LocalDate endDate) {
         List<AvailableModelResponse> response = reservationService.getAvailableModels(startDate, endDate);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<PaginatedResponse<ReservationResponse>> getUserReservations(@AuthenticationPrincipal CustomUserDetails userDetails, Pageable pageable) {
+        UUID authenticatedUserId = userDetails.getId();
+        Page<ReservationResponse> reservationsPage = reservationService.getUserReservations(authenticatedUserId, pageable);
+        PaginatedResponse<ReservationResponse> response = PaginatedResponse.from(reservationsPage);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/velocity/api/reservation/dto/BikeSummary.java
+++ b/src/main/java/com/velocity/api/reservation/dto/BikeSummary.java
@@ -1,0 +1,8 @@
+package com.velocity.api.reservation.dto;
+
+import com.velocity.api.common.City;
+
+import java.util.UUID;
+
+public record BikeSummary(UUID id, String modelName, City city) {
+}

--- a/src/main/java/com/velocity/api/reservation/dto/ReservationResponse.java
+++ b/src/main/java/com/velocity/api/reservation/dto/ReservationResponse.java
@@ -3,17 +3,15 @@ package com.velocity.api.reservation.dto;
 import com.velocity.api.reservation.ReservationStatus;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 
-public record ReservationBookResponse(
+public record ReservationResponse(
         UUID id,
         LocalDate startDate,
         LocalDate endDate,
         BigDecimal totalCost,
         ReservationStatus status,
-        Instant createdAt,
         BikeSummary bike
 ) {
 }

--- a/src/main/java/com/velocity/api/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/com/velocity/api/reservation/mapper/ReservationMapper.java
@@ -1,0 +1,23 @@
+package com.velocity.api.reservation.mapper;
+
+import com.velocity.api.reservation.Reservation;
+import com.velocity.api.reservation.dto.BikeSummary;
+import com.velocity.api.reservation.dto.ReservationResponse;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReservationMapper {
+    public ReservationResponse toDto(Reservation reservation) {
+        return new ReservationResponse(
+                reservation.getId(),
+                reservation.getStartDate(),
+                reservation.getEndDate(),
+                reservation.getTotalCost(),
+                reservation.getStatus(),
+                new BikeSummary(reservation.getBikeInstance().getId(),
+                        reservation.getBikeInstance().getBikeModel().getName(),
+                        reservation.getBikeInstance().getCity()
+                )
+        );
+    }
+}

--- a/src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java
@@ -2,6 +2,9 @@ package com.velocity.api.reservation.repository;
 
 import com.velocity.api.reservation.Reservation;
 import com.velocity.api.reservation.ReservationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -28,4 +31,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, UUID> 
 
     @Query("SELECT r.id FROM Reservation r WHERE r.status = :status AND r.endDate < :today")
     List<UUID> findPastDueConfirmedReservationsIds(@Param("status") ReservationStatus status, @Param("today") LocalDate today);
+
+    @EntityGraph(attributePaths = {"bikeInstance", "bikeInstance.bikeModel", "bikeInstance.id", "bikeInstance.city"})
+    Page<Reservation> findByUserId(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/velocity/api/reservation/service/ReservationService.java
+++ b/src/main/java/com/velocity/api/reservation/service/ReservationService.java
@@ -10,14 +10,15 @@ import com.velocity.api.bike.exception.InvalidBikeStateException;
 import com.velocity.api.common.exception.ResourceNotFoundException;
 import com.velocity.api.reservation.Reservation;
 import com.velocity.api.reservation.ReservationStatus;
-import com.velocity.api.reservation.dto.AvailableModelResponse;
-import com.velocity.api.reservation.dto.ReservationBookRequest;
-import com.velocity.api.reservation.dto.ReservationBookResponse;
+import com.velocity.api.reservation.dto.*;
+import com.velocity.api.reservation.mapper.ReservationMapper;
 import com.velocity.api.reservation.repository.ReservationRepository;
 import com.velocity.api.user.User;
 import com.velocity.api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +36,7 @@ public class ReservationService {
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
     private final RentalCostCalculator rentalCostCalculator;
+    private final ReservationMapper reservationMapper;
 
     @Transactional
     public void transitionStatus(UUID reservationId, ReservationStatus newStatus) {
@@ -72,7 +74,7 @@ public class ReservationService {
                 req.startDate(),
                 req.endDate()
         );
-        ReservationBookResponse.BikeSummary bikeSummary = new ReservationBookResponse.BikeSummary(bike.getId(), bike.getBikeModel().getName(), bike.getCity());
+        BikeSummary bikeSummary = new BikeSummary(bike.getId(), bike.getBikeModel().getName(), bike.getCity());
         return new ReservationBookResponse(
                 bookedReservation.getId(),
                 bookedReservation.getStartDate(),
@@ -115,5 +117,10 @@ public class ReservationService {
         Reservation pastDueConfirmedReservation = reservationRepository.findById(id).orElseThrow(
                 () -> new ResourceNotFoundException("Reservation not found"));
         pastDueConfirmedReservation.transitionTo(ReservationStatus.COMPLETED);
+    }
+
+    public Page<ReservationResponse> getUserReservations(UUID id, Pageable page) {
+        Page<Reservation> reservationsPage = reservationRepository.findByUserId(id, page);
+        return reservationsPage.map(reservationMapper::toDto);
     }
 }

--- a/src/test/java/com/velocity/api/factory/TestDataFactory.java
+++ b/src/test/java/com/velocity/api/factory/TestDataFactory.java
@@ -38,6 +38,17 @@ public class TestDataFactory {
         return userRepository.save(testUser);
     }
 
+    public User createAndSaveUser(String email, String password) {
+        User testUser = User.registerClient(
+                email,
+                password,
+                "Integration Test User",
+                "+48123456729",
+                City.WARSAW
+        );
+        return userRepository.save(testUser);
+    }
+
     public BikeInstance createAndSaveDefaultBike() {
         BikeModel testModel = BikeModel.create(
                 "Integration Test Model " + UUID.randomUUID(),

--- a/src/test/java/com/velocity/api/reservation/ReservationIntegrationTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationIntegrationTest.java
@@ -1,0 +1,101 @@
+package com.velocity.api.reservation;
+
+import com.velocity.api.BaseIntegrationTest;
+import com.velocity.api.bike.BikeInstance;
+import com.velocity.api.bike.repository.BikeInstanceRepository;
+import com.velocity.api.bike.repository.BikeModelRepository;
+import com.velocity.api.factory.TestDataFactory;
+import com.velocity.api.reservation.repository.ReservationRepository;
+import com.velocity.api.user.User;
+import com.velocity.api.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static com.velocity.api.security.SecurityTestHelper.asUser;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Import(TestDataFactory.class)
+public class ReservationIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TestDataFactory testDataFactory;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private BikeInstanceRepository bikeInstanceRepository;
+
+    @Autowired
+    private BikeModelRepository bikeModelRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    public void cleanUp() {
+        reservationRepository.deleteAll();
+        bikeInstanceRepository.deleteAll();
+        bikeModelRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    public void getMyReservations_Unauthenticated_Returns401() throws Exception {
+        mockMvc.perform(get("/api/v1/reservations/my")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void getMyReservations_AuthenticatedUser_ReturnsOnlyTheirReservations() throws Exception {
+        // Arrange Setup Database State
+        User primaryUser = testDataFactory.createAndSaveDefaultUser();
+        // Create a second user to prove we don't leak their data
+        User otherUser = testDataFactory.createAndSaveUser("other@test.com", "123456789");
+
+        BikeInstance bike = testDataFactory.createAndSaveDefaultBike();
+
+        // Primary User makes 2 bookings
+        testDataFactory.createAndSaveReservation(
+                primaryUser, bike, LocalDate.parse("2026-09-01"), LocalDate.parse("2026-09-05")
+        );
+        testDataFactory.createAndSaveReservation(
+                primaryUser, bike, LocalDate.parse("2026-09-10"), LocalDate.parse("2026-09-15")
+        );
+
+        // Other User makes 1 booking (using bounds that don't violate our ADR-001 exclusion constraint)
+        testDataFactory.createAndSaveReservation(
+                otherUser, bike, LocalDate.parse("2026-09-20"), LocalDate.parse("2026-09-25")
+        );
+
+        // Act Perform GET request as primaryUser
+        mockMvc.perform(get("/api/v1/reservations/my?page=0&size=10")
+                        .with(asUser(String.valueOf(primaryUser.getId()), "CLIENT"))
+                        .accept(MediaType.APPLICATION_JSON))
+                // Assert
+                .andExpect(status().isOk())
+                // Verify pagination metadata proves filtering worked at the database level
+                .andExpect(jsonPath("$.meta.totalElements").value(2))
+                .andExpect(jsonPath("$.meta.totalPages").value(1))
+                // Verify the array contains exactly 2 elements
+                .andExpect(jsonPath("$.data.length()").value(2));
+    }
+}


### PR DESCRIPTION
## Context

The frontend require a way to fetch the authenticated user's booking history. 

This PR introduces an endpoint that securely resolves the caller's identity via their JWT and returns a paginated list of their reservations. By strictly using the principal's ID from the security context, we ensure users can only ever access their own data, preventing IDOR vulnerabilities.

Closes #72 

## What Changed

- **Repository:** Added `Page<Reservation> findByUserId(UUID userId, Pageable pageable)` to `ReservationRepository`. 
  - *Tech Note:* Applied `@EntityGraph` to prevent `LazyInitializationException` and avoid N+1 query performance degradation during DTO mapping.
- **Controller:** Implemented `GET /api/v1/reservations/my` in `ReservationController`.
- **Security:** Extracted the caller's UUID dynamically using `@AuthenticationPrincipal`. No explicit `@PreAuthorize` role check is needed since the data is inherently scoped to the caller's token.
- **Response Mapping:** Mapped internal entities to `ReservationResponse` (explicitly exposing the `BikeModel` name and `totalCost` for the frontend UI) and wrapped the result in our standard `PaginatedResponse`.

## Testing

- [x] Unit tests written and passing
- [x] Application compiles and starts successfully
- [x] Wrote `MyReservationsIntegrationTest` (MockMvc)

## Notes FOR the Reviewer