### PR TITLE
feat: add confirm reservation endpoint logic & tests

### DIFF
--- a/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
+++ b/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -53,5 +54,12 @@ public class ReservationController {
         Page<ReservationResponse> reservationsPage = reservationService.getUserReservations(authenticatedUserId, pageable);
         PaginatedResponse<ReservationResponse> response = PaginatedResponse.from(reservationsPage);
         return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{id}/confirm")
+    public ResponseEntity<Void> confirmReservation(@PathVariable UUID id, @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
+        UUID authenticatedUserId = userDetails.getId();
+        reservationService.confirmReservation(id, authenticatedUserId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/velocity/api/reservation/service/ReservationService.java
+++ b/src/main/java/com/velocity/api/reservation/service/ReservationService.java
@@ -20,11 +20,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
-import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -88,9 +88,9 @@ public class ReservationService {
         );
     }
 
-    public List<AvailableModelResponse> getAvailableModels(LocalDate startDate, LocalDate endDate, City city, City userCity) throws AccessDeniedException {
+    public List<AvailableModelResponse> getAvailableModels(LocalDate startDate, LocalDate endDate, City city, City userCity) throws AuthorizationDeniedException {
         if (!userCity.equals(city)) {
-            throw new AccessDeniedException("It's not the authenticated user's city.");
+            throw new AuthorizationDeniedException("It's not the authenticated user's city.");
         }
         List<AvailableModelProjection> availableProjections = bikeInstanceRepository.findAvailableModels(startDate, endDate, city.toString());
         int days = Math.toIntExact(ChronoUnit.DAYS.between(startDate, endDate));
@@ -127,5 +127,16 @@ public class ReservationService {
     public Page<ReservationResponse> getUserReservations(UUID id, Pageable page) {
         Page<Reservation> reservationsPage = reservationRepository.findByUserId(id, page);
         return reservationsPage.map(reservationMapper::toDto);
+    }
+
+    @Transactional
+    public void confirmReservation(UUID reservationId, UUID userId) throws AuthorizationDeniedException {
+        Reservation reservation = reservationRepository.findById(reservationId).orElseThrow(() -> new ResourceNotFoundException("Reservation not found"));
+
+        if (!(reservation.getUser().getId().equals(userId))) {
+            throw new AuthorizationDeniedException("The User cannot access the reservation of other user");
+        }
+
+        reservation.transitionTo(ReservationStatus.CONFIRMED);
     }
 }

--- a/src/test/java/com/velocity/api/reservation/ReservationIntegrationTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationIntegrationTest.java
@@ -4,6 +4,7 @@ import com.velocity.api.BaseIntegrationTest;
 import com.velocity.api.bike.BikeInstance;
 import com.velocity.api.bike.repository.BikeInstanceRepository;
 import com.velocity.api.bike.repository.BikeModelRepository;
+import com.velocity.api.common.exception.ResourceNotFoundException;
 import com.velocity.api.factory.TestDataFactory;
 import com.velocity.api.reservation.repository.ReservationRepository;
 import com.velocity.api.user.User;
@@ -19,9 +20,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 import static com.velocity.api.security.SecurityTestHelper.asUser;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -97,5 +101,55 @@ public class ReservationIntegrationTest extends BaseIntegrationTest {
                 .andExpect(jsonPath("$.meta.totalPages").value(1))
                 // Verify the array contains exactly 2 elements
                 .andExpect(jsonPath("$.data.length()").value(2));
+    }
+
+    @Test
+    public void confirmReservation_AuthorizedUser_Success() throws Exception {
+        User primaryUser = testDataFactory.createAndSaveDefaultUser();
+        BikeInstance bike = testDataFactory.createAndSaveDefaultBike();
+
+        Reservation reservation = testDataFactory.createAndSaveReservation(
+                primaryUser, bike, LocalDate.parse("2026-09-01"), LocalDate.parse("2026-09-05")
+        );
+
+        UUID reservationId = reservation.getId();
+        UUID primaryUserId = primaryUser.getId();
+
+        // Act confirm request as otherUser
+        mockMvc.perform(post("/api/v1/reservations/%s/confirm".formatted(reservationId))
+                        .with(asUser(String.valueOf(primaryUserId), "CLIENT"))
+                )
+                // Assert
+                .andExpect(status().isNoContent());
+        Reservation freshReservation = reservationRepository.findById(reservationId).orElseThrow(() ->
+                new ResourceNotFoundException("Reservation not found."));
+        assertThat(freshReservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+
+    }
+
+    @Test
+    public void confirmReservation_UnauthorizedUser_Forbidden() throws Exception {
+        User primaryUser = testDataFactory.createAndSaveDefaultUser();
+        User otherUser = testDataFactory.createAndSaveUser("other@test.com", "123456789");
+        BikeInstance bike = testDataFactory.createAndSaveDefaultBike();
+
+        Reservation reservation = testDataFactory.createAndSaveReservation(
+                primaryUser, bike, LocalDate.parse("2026-09-01"), LocalDate.parse("2026-09-05")
+        );
+
+        UUID reservationId = reservation.getId();
+        UUID otherUserId = otherUser.getId();
+
+
+        mockMvc.perform(post("/api/v1/reservations/%s/confirm".formatted(reservationId))
+                        .with(asUser(String.valueOf(otherUserId), "CLIENT"))
+                )
+                // Assert
+                .andExpect(status().isForbidden());
+
+        Reservation freshReservation = reservationRepository.findById(reservationId).orElseThrow(() ->
+                new ResourceNotFoundException("Reservation not found."));
+        assertThat(freshReservation.getStatus()).isEqualTo(ReservationStatus.PENDING);
+
     }
 }


### PR DESCRIPTION
## Context

To complete the simulated checkout flow, reservations are initially created in the `PENDING` state. This change introduces the dedicated endpoint to trigger the transition from `PENDING` to `CONFIRMED` upon successful payment simulation. It strictly adheres to **ADR-002 (Rich Domain Model)** by delegating state invariant enforcement directly to the domain entity rather than the service layer, while securing the endpoint against Insecure Direct Object Reference (IDOR) vulnerabilities.

Closes #74 

## What Changed

- **Controller Layer:** Added `POST /v1/reservations/{id}/confirm` endpoint in `ReservationController` returning an HTTP `204 No Content` upon successful transition.
- **Service Layer Orchestration:** Implemented `confirmReservation(UUID reservationId, UUID userId)` in `ReservationService` within a `@Transactional` boundary, including explicit ownership verification to prevent IDOR.
- **Rich Domain Model (ADR-002):** Delegated state validation and transition mechanics directly to the `Reservation` entity via `reservation.transitionTo(ReservationStatus.CONFIRMED)`.
- **Integration Tests:** Expanded `ReservationIntegrationTest` with comprehensive test coverage:
  - Authorized owner successfully transitioning a `PENDING` reservation to `CONFIRMED` (verified via both HTTP status and direct PostgreSQL repository state inspection).
  - Unauthorized user attempting to confirm another user's booking, receiving an HTTP `403 Forbidden` response while leaving the database state strictly unmodified (`PENDING`).



## Testing
- [x] Unit/Integration tests written and passing (`mvn clean test` is green)
- [x] Application compiles and starts successfully