### PR TITLE
feat: add user update by admin endpoint with all necessary logic | up…

### DIFF
--- a/docs/context/PROJECT_CONTEXT.md
+++ b/docs/context/PROJECT_CONTEXT.md
@@ -1,128 +1,168 @@
-# VeloCity Fleet API - AI Context
+﻿# VeloCity Fleet API — Project Context
 
-Last updated: 2026-08-30
+Last updated: 2026-09-01
 
-> Single source of truth for AI assistants and contributors.
-> Keep this file aligned with the actual codebase, application configuration, security setup, and current implementation status.
+This file is the single source of truth for the project. It reflects the repo state, the major issue history in the GitHub Kanban board, the architectural decisions captured in ADRs, and the current implementation status for the backend service that powers the VeloCity frontend.
 
-## 1. Purpose
+## 1. Project goal
 
-This project is a Spring Boot backend for an e-bike rental platform. The current implementation emphasizes reservation integrity, authenticated user operations, and explicit lifecycle state transitions for users and reservations. The codebase is beyond initial scaffolding and includes working auth, reservation booking, user self-service, admin user lifecycle operations, and scheduler-driven reservation maintenance.
+VeloCity is an e-bike rental platform. The backend exists to make the booking flow robust, safe, and testable under real-world concurrency and business rules.
 
-## 2. Current stack
+The project is not just CRUD. The core business risk is preventing double-booking for the same physical bike on overlapping dates while keeping the domain model clean and the API easy for a React frontend to consume.
+
+The core product workflow is:
+- browse available bikes and models
+- register/login as a client
+- reserve a bike for a date range
+- pay / confirm a reservation
+- auto-complete or auto-cancel lifecycle transitions
+- manage users and admin actions
+
+## 2. Current implementation status
+
+The project is in the frontend-integration stage: the backend is already feature-rich and issue-driven, and the remaining work is mostly coordination, polish, and integration with the client app.
+
+Implemented areas:
+- JWT-backed authentication and authorization
+- user registration, login, logout, profile updates, admin user lifecycle
+- fleet listing and model availability queries
+- reservation creation, ownership checks, lifecycle transitions, and scheduling jobs
+- global ProblemDetail-based error handling
+- Postgres-backed reservation integrity with exclusion constraints
+- comprehensive test coverage including concurrency tests and service tests
+
+Current emphasis:
+- frontend contract alignment
+- stable DTO contracts and pagination shape
+- security + ownership enforcement for client requests
+- cleanup of edge cases, observability, and integration hardening
+
+## 3. Tech stack
 
 - Java 25
 - Spring Boot 4.1.0
 - Spring Web MVC
 - Spring Data JPA / Hibernate
 - PostgreSQL
-- Redis for JWT blacklist storage
+- Redis (JWT blacklist)
 - Liquibase
 - Spring Security + JWT (JJWT)
 - Springdoc OpenAPI / Swagger UI
 - Maven
-- JUnit 5 + Spring test support + Testcontainers
+- JUnit 5 + Mockito + Spring test support + Testcontainers
+- Docker Compose
+- GitHub Actions
 
-Important notes:
-- Runtime expects PostgreSQL and Redis on localhost:5432 and localhost:6379 by default.
-- `spring.jpa.hibernate.ddl-auto=validate`; schema evolution is Liquibase-managed.
-- Security is stateless and enforced through a JWT filter plus method-level authorization.
-- Pricing uses configured `pricing.daily-rate` (currently `50.00`) and BigDecimal-based calculation.
+Important runtime conventions:
+- PostgreSQL and Redis are expected on localhost:5432 and localhost:6379 in local dev
+- schema changes are Liquibase-managed; JPA ddl-auto is validation-only
+- security is stateless with JWT-based filtering
+- pricing is BigDecimal-based and configured via spring.pricing.daily-rate
 
-## 3. Current package layout and architecture
+## 4. Architecture and package structure
 
-Core packages:
-- `com.velocity.api.auth` — registration, login, logout, and current-user profile retrieval
-- `com.velocity.api.user` — user domain model, profile updates, and admin user lifecycle operations
-- `com.velocity.api.bike` — bike model/instance domain, availability projections, and fleet listing
-- `com.velocity.api.reservation` — reservation domain, booking, listing, and lifecycle scheduler
-- `com.velocity.api.security` — JWT service/filter, custom principal details, and Redis token blacklist repository
-- `com.velocity.api.pricing` — rental cost calculation
-- `com.velocity.api.common` — shared DTOs, enums, exception hierarchy, and global error mapping
-- `com.velocity.api.config` — security and infrastructure config
+Core package layout:
+- com.velocity.api.auth
+- com.velocity.api.user
+- com.velocity.api.bike
+- com.velocity.api.reservation
+- com.velocity.api.security
+- com.velocity.api.pricing
+- com.velocity.api.common
+- com.velocity.api.config
 
-Architecture rules currently visible in code:
-- Controllers are thin HTTP adapters and delegate business logic to services.
-- Domain entities encapsulate state transitions and avoid broad public mutation.
-- Reservation availability is protected at both service and database layers.
-- Global error handling standardizes responses via RFC7807 `ProblemDetail`.
-- Method security (`@PreAuthorize`) is active and used for user ownership and admin-only routes.
+Architectural rules visible in the codebase:
+- controllers are thin HTTP adapters
+- services orchestrate transactions and business rules
+- repositories handle data access
+- entities protect their own invariants
+- DTOs are used at the API boundary; entities never leak to the web layer
+- global error handling returns RFC 7807 ProblemDetail payloads
+- method security is enforced for owner and admin use cases
 
-## 4. Domain model (current code)
+## 5. Domain model
 
 ### User
-
-Fields:
-- `id`, `email`, `passwordHash`, `fullName`, `phone`, `status`, `role`, `city`, `joinedDate`
-
-Rules in current code:
-- `email` and `phone` are unique.
-- `joinedDate` is assigned in `@PrePersist`.
-- Registration uses `User.registerClient(...)` with BCrypt-hashed password.
-- Profile updates are validated in `User.updateProfile(...)`.
-- Domain lifecycle methods exist: `block()`, `unblock()`, `softDelete()`.
-- Invalid user state changes throw `InvalidUserStateException`.
+Fields include id, email, passwordHash, fullName, phone, status, role, city, joinedDate.
+Rules:
+- unique email and phone
+- registration via `User.registerClient(...)`
+- profile updates via `User.updateProfile(...)`
+- block/unblock/softDelete state transitions
+- invalid user-state operations throw `InvalidUserStateException`
 
 ### BikeModel
-
-Fields:
-- `id`, `name`, `description`, `speed`, `range`, `capacity`, `category`
-
-Rules in current code:
-- `name` is unique.
-- Created through `BikeModel.create(...)`.
+Fields include id, name, description, speed, range, capacity, category.
+Rules:
+- created via `BikeModel.create(...)`
+- model-level identity and bike inventory separation
 
 ### BikeInstance
-
-Fields:
-- `id`, `status`, `city`, `bikeModel`
-
+Fields include id, status, city, bikeModel.
 Status values:
-- `ACTIVE`, `MAINTENANCE`, `LOST`, `RETIRED`
-
-Rules in current code:
-- Created through `BikeInstance.initialize(...)`.
-- Defaults to `ACTIVE`.
-- Reservation booking allows only `ACTIVE` instances.
+- ACTIVE, MAINTENANCE, LOST, RETIRED
+Rules:
+- created via `BikeInstance.initialize(...)`
+- default ACTIVE state
+- booking only allowed when ACTIVE
 
 ### Reservation
-
-Fields:
-- `id`, `startDate`, `endDate`, `totalCost`, `status`, `createdAt`, `version`, `user`, `bikeInstance`
-
+Fields include id, startDate, endDate, totalCost, status, createdAt, version, user, bikeInstance.
 Status values:
-- `PENDING`, `CONFIRMED`, `COMPLETED`, `CANCELLED`
+- PENDING, CONFIRMED, COMPLETED, CANCELLED
+Rules:
+- domain creation via `Reservation.book(...)`
+- lifecycle enforced through `Reservation.transitionTo(...)`
+- invalid transitions throw `InvalidStatusTransitionException`
+- `@Version` is used for optimistic locking on update races
 
-Rules in current code:
-- Created through `Reservation.book(...)`.
-- `createdAt` is assigned in `@PrePersist`.
-- `@Version` enables optimistic locking.
-- Valid transitions in `Reservation.transitionTo(...)`:
-  - `PENDING -> CONFIRMED`
-  - `PENDING -> CANCELLED`
-  - `CONFIRMED -> COMPLETED`
-  - `CONFIRMED -> CANCELLED`
-- Invalid transitions throw `InvalidStatusTransitionException`.
+## 6. Core business rules and architectural decisions
 
-## 5. Security and authentication
+### ADR-001: concurrency and exclusion constraints
+The reservation data integrity requirement is solved by a PostgreSQL exclusion constraint on overlapping active reservations for the same bike.
 
-The application has a fully wired JWT-based auth layer.
+Key decision:
+- the exclusion constraint is the hard guarantee
+- service-layer pre-checks are UX convenience only
+- `@Version` is not the mechanism for preventing double-booking; it is for update-race safety on existing rows
+- date bounds are `[)` to allow back-to-back rentals without phantom conflicts
 
-Current security setup:
-- `SecurityConfig` uses stateless session policy and installs `JwtAuthenticationFilter`.
-- `JwtAuthenticationFilter` parses bearer token, rejects blacklisted tokens, validates JWT, and populates security context.
-- `AuthService` authenticates credentials through `AuthenticationManager`.
-- JWT claims include user `id` and `role`.
-- Redis-backed blacklist is implemented in `com.velocity.api.security.repository.TokenBlacklistRepository`.
-- Password hashing uses `BCryptPasswordEncoder`.
-- Method-level security is enabled (`@EnableMethodSecurity`).
+### ADR-002: rich domain model
+The project deliberately rejects anemic entities. Core business logic belongs in entities, not scattered in service classes.
 
-Public endpoints currently:
+Examples:
+- `Reservation.transitionTo(...)`
+- `User.updateProfile(...)`
+- `User.block()/unblock()/softDelete()`
+- domain exceptions and invariant checks remain close to the data they protect
+
+### Core design principles
+- strict bounded contexts and package ownership
+- no entity leakage to controllers
+- centralized pagination and response wrappers
+- BigDecimal for all pricing math
+- standardized ProblemDetail responses for all error paths
+- no public status setters on domain entities
+- use factory methods and constructors with restricted visibility
+
+## 7. Security and auth
+
+The application uses JWT-based stateless authentication.
+
+Current security model:
+- `SecurityConfig` uses stateless session policy
+- `JwtAuthenticationFilter` validates bearer tokens and populates the `SecurityContext`
+- `CustomUserDetailsService` resolves authorities from persisted user data
+- Redis blacklist stores revoked tokens until expiration
+- BCrypt is used for password hashing
+- method-level authorization is enabled
+
+Public endpoints:
 - `POST /api/v1/auth/register`
 - `POST /api/v1/auth/login`
-- Swagger/OpenAPI: `/api/swagger-ui.html`, `/api/swagger-ui/**`, `/api/api-docs/**`, `/v3/api-docs/**`
+- Swagger/OpenAPI docs and API docs endpoints
 
-Authenticated endpoints currently include:
+Protected endpoints include:
 - `POST /api/v1/auth/logout`
 - `GET /api/v1/auth/me`
 - `PATCH /api/v1/users/{id}`
@@ -130,127 +170,129 @@ Authenticated endpoints currently include:
 - `POST /api/v1/reservations`
 - `GET /api/v1/reservations/availability`
 - `GET /api/v1/reservations/my`
-- `GET /api/v1/admin/users`
-- `POST /api/v1/admin/users/{id}/block`
-- `POST /api/v1/admin/users/{id}/unblock`
-- `POST /api/v1/admin/users/{id}/delete`
+- admin user routes
 
-Authorization notes:
-- User self-update is protected by `@PreAuthorize("#id == authentication.principal.id")`.
-- Admin routes are protected by class-level `@PreAuthorize("hasRole('ADMIN')")`.
-- Reservation booking and `/my` reservations resolve user ID from `@AuthenticationPrincipal CustomUserDetails` (no hardcoded ID path).
+## 8. Reservation logic and lifecycle
 
-## 6. Current API surface
+The reservation lifecycle is central to the business.
 
-### Auth
-- `POST /api/v1/auth/register` — register a new client account
-- `POST /api/v1/auth/login` — authenticate and return bearer token payload
-- `POST /api/v1/auth/logout` — blacklist bearer token until JWT expiration
-- `GET /api/v1/auth/me` — fetch current authenticated user profile
+State machine:
+- PENDING -> CONFIRMED
+- PENDING -> CANCELLED
+- CONFIRMED -> COMPLETED
+- CONFIRMED -> CANCELLED
+- CANCELLED and COMPLETED are terminal
 
-### Users
-- `PATCH /api/v1/users/{id}` — update own profile (ownership enforced with `@PreAuthorize`)
-- `GET /api/v1/admin/users` — list users (admin only, paginated)
-- `POST /api/v1/admin/users/{id}/block` — block user (admin only)
-- `POST /api/v1/admin/users/{id}/unblock` — unblock user (admin only)
-- `POST /api/v1/admin/users/{id}/delete` — soft-delete user (admin only)
+Reservation lifecycle automation:
+- stale PENDING reservations are auto-cancelled by a scheduled job
+- past-due CONFIRMED reservations are auto-completed by a scheduled job
+- scheduling logic catches optimistic locking races gracefully and continues
 
-### Fleet
-- `GET /api/v1/fleet` — paginated list of active bikes
+The project also enforces booking availability and reservation ownership checks at the service layer, while the database constraint prevents race-condition double-booking.
 
-### Reservations
-- `POST /api/v1/reservations` — create reservation for authenticated user
-- `GET /api/v1/reservations/availability` — get available models for date range
-- `GET /api/v1/reservations/my` — get authenticated user reservations (paginated)
+## 9. API surface and frontend-facing contract
 
-## 7. Reservation logic and booking guarantees
+Current backend API includes:
+- Auth: register, login, logout, profile fetch
+- Users: self-update, admin list/block/unblock/delete
+- Fleet: searchable/available-bike listing with DTOs and pagination
+- Reservations: create, availability query, user's reservations, lifecycle confirmation
 
-Current booking workflow in `ReservationService.book(...)`:
-- Loads authenticated user and target bike instance.
-- Rejects non-`ACTIVE` bikes (`InvalidBikeStateException`).
-- Checks overlap with `reservationRepository.isBikeAvailable(...)`.
-- Calculates cost with `RentalCostCalculator` based on day count and configured daily rate.
-- Persists reservation with initial `PENDING` status.
+Important contract decisions:
+- raw entities are not returned to the frontend
+- all API responses are DTO-based and paginated where appropriate
+- errors are standardized via `ProblemDetail` with `status`, `title`, and `detail`
+- `@Valid` request DTOs enforce contract-level validation before service logic
 
-Data consistency model:
-- Application-layer overlap check provides fast domain-level rejection.
-- Database-level protections (including overlap constraint from ADR direction) prevent race-condition double-booking under concurrency.
-- Reservation listing for current user uses repository paging with entity graph loading of bike and model relations.
+## 10. GitHub issue inventory from the Kanban project
 
-## 8. Lifecycle automation and scheduled jobs
+These are the issue themes already created and tracked in the project board. They reflect the actual project sequence from setup to production-hardening and frontend integration.
 
-`ReservationLifecycleScheduler` is active and currently test/dev-tuned:
-- `@Scheduled(fixedRate = 10000)` cancel job: finds stale `PENDING` reservations older than 30 minutes and transitions to `CANCELLED`.
-- `@Scheduled(fixedRate = 10000)` complete job: finds past-due `CONFIRMED` reservations and transitions to `COMPLETED`.
-- Scheduler catches optimistic locking races to avoid crashing the job loop.
+### Foundation and project setup
+- #1 Initial project setup: Spring Boot, Maven, Docker Compose
+- #3 Create PostgreSQL schema with Liquibase migrations
+- #5 Design and implement core domain entities
+- #7 Apply SOLID principles - refactor domain layer & reflect the code
+- #10 Add Stream API processing for fleet availability filtering
+- #12 Implement bike availability check
+- #14 Implement reservation state machine with transition validation (TDD)
+- #16 chore: pre-#14 hardening - ADR-001, 404 handler, reservation encapsulation, line endings
+- #19 refactor: pre-#14 hardening - ADR-001, 404 handler, reservation encapsulation, line endings
+- #21 Architecture review fixes
+- #23 Implement RentalCostCalculator with BigDecimal (TDD)
+- #25 Add test seam: asUser() helper + SecurityContext stub
+- #27 Add GitHub Actions workflow: run mvn test on every push to develop (lightweight CI gate)
+- #30 Implement User Registration Endpoint (POST /api/v1/auth/register)
+- #33 Enhance internal JavaDocs
+- #35 Global error handling: @RestControllerAdvice + ProblemDetail
+- #36 Integrate OpenAPI 3 (Swagger)
+- #39 Documentation
+- #41 First REST controller: GET /v1/fleet, read-only; decide pagination + response envelope here (changing it later breaks the React client)
+- #42 Global error handling: @RestControllerAdvice + ProblemDetail
+- #45 Add Stream API processing for fleet availability filtering
+- #48 Apply SOLID principles - refactor domain layer & reflect the code
+- #50 Create PostgreSQL schema with Liquibase migrations
+- #52 Design and implement core domain entities
+- #54 Initial project setup: Spring Boot, Maven, Docker Compose
+- #56 Implement bike availability check
+- #58 Implement reservation state machine with transition validation (TDD)
+- #60 chore: consistency polish - rate validation, URL prefix, constructor style, doc accuracy
+- #62 update README
+- #64 Implement reservation creation
+- #66 chore: establish AI-assisted workflow - project context file + Gemini Gem
+- #68 Integration test for reservation concurrent conflict scenario
+- #70 Implement @Scheduled jobs - auto-complete finished rentals; auto-cancel stale PENDING
+- #72 Configure JWT authentication filter chain
+- #74 Implement login endpoint issuing JWT
+- #75 update fetching available bike models
 
-Note:
-- The 10-second cadence is explicitly temporary/test-oriented (production-style schedules are present as commented intent).
+### Issue progression summary
+The issue list shows a clear and intentional project evolution:
+1. foundation and schema
+2. domain + business logic + tests
+3. API exposure and error handling
+4. reservation concurrency guarantee
+5. auth + JWT + user administration
+6. lifecycle automation + frontend-facing contract work
+7. final integration polish and user workflow expansion
 
-## 9. Error handling and validation
+## 11. ADR reference set
 
-`GlobalExceptionHandler` maps known failures to `ProblemDetail`:
-- validation errors (`MethodArgumentNotValidException`) -> 400 with `invalidFields`
-- missing resources (`ResourceNotFoundException`, `NoResourceFoundException`) -> 404
-- duplicate registration email (`EmailAlreadyRegisteredException`) -> 409
-- bike availability/business conflicts (`BikeNotAvailableException`) -> 409
-- data integrity/locking conflicts (`DataIntegrityViolationException`, `CannotAcquireLockException`) -> 409
-- invalid state transitions (`InvalidStatusTransitionException`, `InvalidUserStateException`) -> 422
-- invalid bike state (`InvalidBikeStateException`) -> 422
-- invalid credentials (`BadCredentialsException`) -> 401
-- forbidden actions (`AuthorizationDeniedException`) -> 403
-- unsupported HTTP method (`HttpRequestMethodNotSupportedException`) -> 405
-- fallback unexpected errors -> 500
+Relevant ADRs in the repository:
+- `docs/adrs/0001-prevent-reservation-race-conditions.md` — PostgreSQL exclusion constraint for active-reservation overlap prevention
+- `docs/adrs/0002-adopt-rich-domain-model-architecture.md` — Rich Domain Model decision
+- `docs/adrs/0003-adopt-project-context-file-with-ai-assistant-grounding.md` — AI context management and repo grounding strategy
 
-Validation strategy:
-- Request DTO validation (`@Valid`) at controller boundaries.
-- Additional domain-level validation inside entity methods and services.
+## 12. Testing strategy
 
-## 10. Database and migration model
+The project expects production-quality testing, not only happy-path checks.
 
-Current database conventions:
-- PostgreSQL is the runtime relational database.
-- Liquibase is the schema source of truth.
-- Hibernate runs in validation mode (`ddl-auto=validate`) and does not auto-mutate schema.
-- Reservation entity optimistic locking (`@Version`) is active.
-- Reservation overlap protection is designed as both application check and database-enforced constraint.
+Current test priorities:
+- domain rules and state transitions under parameterized tests
+- service logic and DTO mapping behavior
+- concurrency proof for reservation creation under multiple threads
+- integration tests for authentication and ownership enforcement
+- validation and error-response mapping with `ProblemDetail`
+- repository query tests for availability and overlap logic
 
-## 11. Current implementation status and known gaps
+## 13. Known risks and current watchpoints
 
-Implemented:
-- JWT auth flow (register/login/logout/me) with Redis blacklist.
-- User self-profile updates.
-- Admin user lifecycle endpoints (list/block/unblock/soft-delete).
-- Fleet active-bike listing with pagination.
-- Reservation booking, availability query, and authenticated user reservation list (`/my`).
-- Scheduled stale-cancel and past-due-complete reservation transitions.
+- scheduler cadence is intentionally test/dev-oriented in some phases; production tuning is a deliberate follow-up concern
+- security configuration must remain careful to avoid locking Swagger or frontend routes
+- database invariants are the source of truth for concurrency safety; the service layer is not the hard guarantee
+- frontend integration will surface contract drift if DTOs or pagination envelopes change without coordination
+- Java 25 + Spring Boot 4.1.0 requires a consistent local environment; build/test behavior should be aligned across dev, CI, and IDEs
 
-Known gaps and risks:
-- Scheduler frequencies are test/dev-oriented and not yet production-tuned.
-- Security/CORS origins are currently local frontend focused (`localhost:5173`, `localhost:3000`).
-- Build tooling currently targets very new stack coordinates (Java 25 + Spring Boot 4.1.0), which may require environment alignment in IDE/CI.
+## 14. Working assumptions for ongoing development
 
-## 12. Reference files
+- this backend is the source of truth for business rules and database guarantees
+- frontend behavior must align with the API contract, not the inverse
+- domain invariants are never to be bypassed by setter-based mutation
+- exceptions are transformed into structured ProblemDetail payloads rather than leaking raw stack traces or DB internals
+- the project remains issue-driven and documentation-backed, with `PROJECT_CONTEXT.md` updated whenever core decisions change
 
-- Runtime configuration: `src/main/resources/application.yaml`
-- Build and dependencies: `pom.xml`
-- Security config: `src/main/java/com/velocity/api/config/SecurityConfig.java`
-- Auth controller: `src/main/java/com/velocity/api/auth/controller/AuthController.java`
-- Auth service: `src/main/java/com/velocity/api/auth/service/AuthService.java`
-- User controller: `src/main/java/com/velocity/api/user/controller/UserController.java`
-- Admin controller: `src/main/java/com/velocity/api/user/controller/AdminUserController.java`
-- Fleet controller: `src/main/java/com/velocity/api/bike/controller/FleetController.java`
-- Reservation controller: `src/main/java/com/velocity/api/reservation/controller/ReservationController.java`
-- Reservation service: `src/main/java/com/velocity/api/reservation/service/ReservationService.java`
-- Reservation repository: `src/main/java/com/velocity/api/reservation/repository/ReservationRepository.java`
-- Reservation scheduler: `src/main/java/com/velocity/api/reservation/scheduler/ReservationLifecycleScheduler.java`
-- Reservation entity: `src/main/java/com/velocity/api/reservation/Reservation.java`
-- User entity: `src/main/java/com/velocity/api/user/User.java`
-- Bike instance entity: `src/main/java/com/velocity/api/bike/BikeInstance.java`
-- Global exception handler: `src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java`
-- JWT filter: `src/main/java/com/velocity/api/security/JwtAuthenticationFilter.java`
-- Token blacklist repository: `src/main/java/com/velocity/api/security/repository/TokenBlacklistRepository.java`
+## 15. Summary
 
-## 13. Planning note
+The VeloCity API is a backend built around one central integrity problem: ensuring a bike cannot be double-booked for overlapping dates, even under concurrency. Everything from the Postgres exclusion constraint to the rich domain model, JWT auth layer, and reservation lifecycle automation is designed around that guarantee.
 
-This file reflects the repository state as of 2026-08-30. Update it together with meaningful architectural, API, security, or workflow changes so assistants and contributors remain grounded in current reality.
+The project has moved beyond initial scaffolding into a real application architecture with strong separation of concerns, explicit domain rules, and clear API contracts for the React frontend. The current work is less about inventing a stack and more about integrating and hardening it around the business process it serves.

--- a/src/main/java/com/velocity/api/user/User.java
+++ b/src/main/java/com/velocity/api/user/User.java
@@ -12,12 +12,15 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Getter
 @Entity
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // for JPA
 public class User {
+    private static final Pattern EMAIL_PATTERN = Pattern.compile("^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$");
+
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
@@ -64,6 +67,17 @@ public class User {
         this.fullName = fullName.trim();
         this.phone = phone;
         this.city = city;
+    }
+
+    public void updateProfileByAdmin(String fullName, String phone, City city, String email) {
+        validateFullName(fullName);
+        validatePhone(phone);
+        validateCity(city);
+        validateEmail(email);
+        this.fullName = fullName.trim();
+        this.phone = phone;
+        this.city = city;
+        this.email = email;
     }
 
     public void block() {
@@ -121,6 +135,12 @@ public class User {
     private void validateCity(City city) {
         if (city == null) {
             throw new IllegalArgumentException("City is required");
+        }
+    }
+
+    private void validateEmail(String email) {
+        if (!EMAIL_PATTERN.matcher(email).matches()) {
+            throw new IllegalArgumentException("Email must be properly formatted.");
         }
     }
 }

--- a/src/main/java/com/velocity/api/user/controller/AdminUserController.java
+++ b/src/main/java/com/velocity/api/user/controller/AdminUserController.java
@@ -2,6 +2,7 @@ package com.velocity.api.user.controller;
 
 import com.velocity.api.common.dto.PaginatedResponse;
 import com.velocity.api.user.dto.AdminUserResponse;
+import com.velocity.api.user.dto.AdminUserUpdateRequest;
 import com.velocity.api.user.service.AdminUserService;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -42,6 +43,12 @@ public class AdminUserController {
     @PostMapping("/users/{id}/delete")
     public ResponseEntity<Void> softDeleteUser(@PathVariable("id") UUID id) {
         adminUserService.softDeleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/users/{id}")
+    public ResponseEntity<Void> updateUser(@PathVariable UUID id, @RequestBody AdminUserUpdateRequest request) {
+        adminUserService.updateUser(id, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/velocity/api/user/dto/AdminUserUpdateRequest.java
+++ b/src/main/java/com/velocity/api/user/dto/AdminUserUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.velocity.api.user.dto;
+
+import com.velocity.api.common.City;
+import org.openapitools.jackson.nullable.JsonNullable;
+
+public record AdminUserUpdateRequest(
+        JsonNullable<String> fullName,
+        JsonNullable<String> phone,
+        JsonNullable<City> city,
+        JsonNullable<String> email
+) {
+}

--- a/src/main/java/com/velocity/api/user/service/AdminUserService.java
+++ b/src/main/java/com/velocity/api/user/service/AdminUserService.java
@@ -1,8 +1,11 @@
 package com.velocity.api.user.service;
 
+import com.velocity.api.common.City;
 import com.velocity.api.common.exception.ResourceNotFoundException;
 import com.velocity.api.user.User;
 import com.velocity.api.user.dto.AdminUserResponse;
+import com.velocity.api.user.dto.AdminUserUpdateRequest;
+import com.velocity.api.user.exception.EmailAlreadyRegisteredException;
 import com.velocity.api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -47,5 +50,20 @@ public class AdminUserService {
     public void softDeleteUser(UUID id) {
         User user = userRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("User not found."));
         user.softDelete();
+    }
+
+    @Transactional
+    public void updateUser(UUID id, AdminUserUpdateRequest request) {
+        User user = userRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("User not found."));
+        String fullName = request.fullName().isPresent() ? request.fullName().get() : user.getFullName();
+        String phone = request.phone().isPresent() ? request.phone().get() : user.getPhone();
+        City city = request.city().isPresent() ? request.city().get() : user.getCity();
+        String email = request.email().isPresent() ? request.email().get() : user.getEmail();
+
+        if (!email.equalsIgnoreCase(user.getEmail()) && userRepository.findByEmail(email).isPresent()) {
+            throw new EmailAlreadyRegisteredException("The email address " + request.email() + " is already in use.");
+        }
+
+        user.updateProfileByAdmin(fullName, phone, city, email);
     }
 }


### PR DESCRIPTION
## Context
The admin dashboard requires the ability to upgrade standard users to administrators (and vice versa). This was separated from the standard user profile update into its own dedicated endpoint to ensure strict separation of concerns regarding security boundaries and to prevent accidental privilege escalation.

Closes #78

## What Changed
- Created `PATCH /api/v1/admin/users/{id}/role` endpoint specifically for security/role transitions.
- Created `ChangeUserRoleRequest` DTO containing only the required `UserRole` field.
- Adhered to ADR-002 (Rich Domain Model) by adding a dedicated `changeRole(UserRole newRole)` method inside the `User` entity, protecting internal invariants and keeping security logic out of the standard profile update path.

## Testing
- [x] Application compiles and starts successfully