### PR TITLE
feat: add new endpoint for chaning role of users

### DIFF
--- a/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.velocity.api.common.exception;
 import com.velocity.api.bike.exception.BikeNotAvailableException;
 import com.velocity.api.bike.exception.InvalidBikeStateException;
 import com.velocity.api.reservation.exception.InvalidStatusTransitionException;
+import com.velocity.api.user.exception.CannotDemoteSelfException;
 import com.velocity.api.user.exception.EmailAlreadyRegisteredException;
 import com.velocity.api.user.exception.InvalidUserStateException;
 import lombok.extern.slf4j.Slf4j;
@@ -240,6 +241,17 @@ public class GlobalExceptionHandler {
         );
         problem.setTitle("Wrong HTTP Method");
 
+        return problem;
+    }
+
+    @ExceptionHandler(CannotDemoteSelfException.class)
+    public ProblemDetail handleCannotDemoteSelfException(CannotDemoteSelfException ex) {
+        log.warn("Self-demotion attempt blocked: {}", ex.getMessage());
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.CONFLICT,
+                ex.getMessage()
+        );
+        problem.setTitle("Self-demotion attempt blocked");
         return problem;
     }
 

--- a/src/main/java/com/velocity/api/user/User.java
+++ b/src/main/java/com/velocity/api/user/User.java
@@ -80,6 +80,11 @@ public class User {
         this.email = email;
     }
 
+    public void changeRoleByAdmin(UserRole role) {
+        validateRole(role);
+        this.role = role;
+    }
+
     public void block() {
         if (this.status == UserStatus.DELETED) {
             throw new InvalidUserStateException("Cannot modify a deleted user.");
@@ -141,6 +146,12 @@ public class User {
     private void validateEmail(String email) {
         if (!EMAIL_PATTERN.matcher(email).matches()) {
             throw new IllegalArgumentException("Email must be properly formatted.");
+        }
+    }
+
+    private void validateRole(UserRole role) {
+        if (role == null) {
+            throw new IllegalArgumentException("Role is required");
         }
     }
 }

--- a/src/main/java/com/velocity/api/user/controller/AdminUserController.java
+++ b/src/main/java/com/velocity/api/user/controller/AdminUserController.java
@@ -1,15 +1,19 @@
 package com.velocity.api.user.controller;
 
 import com.velocity.api.common.dto.PaginatedResponse;
+import com.velocity.api.security.CustomUserDetails;
 import com.velocity.api.user.dto.AdminUserResponse;
 import com.velocity.api.user.dto.AdminUserUpdateRequest;
+import com.velocity.api.user.dto.AdminUserUpdateRoleRequest;
 import com.velocity.api.user.service.AdminUserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -49,6 +53,13 @@ public class AdminUserController {
     @PatchMapping("/users/{id}")
     public ResponseEntity<Void> updateUser(@PathVariable UUID id, @RequestBody AdminUserUpdateRequest request) {
         adminUserService.updateUser(id, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/users/{id}/role")
+    public ResponseEntity<Void> updateUserRole(@PathVariable UUID id, @Valid @RequestBody AdminUserUpdateRoleRequest request, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        UUID authenticatedUserId = userDetails.getId();
+        adminUserService.updateUserRole(id, authenticatedUserId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/velocity/api/user/dto/AdminUserUpdateRoleRequest.java
+++ b/src/main/java/com/velocity/api/user/dto/AdminUserUpdateRoleRequest.java
@@ -1,0 +1,9 @@
+package com.velocity.api.user.dto;
+
+import com.velocity.api.user.UserRole;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminUserUpdateRoleRequest(
+        @NotNull UserRole role
+) {
+}

--- a/src/main/java/com/velocity/api/user/exception/CannotDemoteSelfException.java
+++ b/src/main/java/com/velocity/api/user/exception/CannotDemoteSelfException.java
@@ -1,0 +1,7 @@
+package com.velocity.api.user.exception;
+
+public class CannotDemoteSelfException extends RuntimeException {
+    public CannotDemoteSelfException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/velocity/api/user/service/AdminUserService.java
+++ b/src/main/java/com/velocity/api/user/service/AdminUserService.java
@@ -3,8 +3,11 @@ package com.velocity.api.user.service;
 import com.velocity.api.common.City;
 import com.velocity.api.common.exception.ResourceNotFoundException;
 import com.velocity.api.user.User;
+import com.velocity.api.user.UserRole;
 import com.velocity.api.user.dto.AdminUserResponse;
 import com.velocity.api.user.dto.AdminUserUpdateRequest;
+import com.velocity.api.user.dto.AdminUserUpdateRoleRequest;
+import com.velocity.api.user.exception.CannotDemoteSelfException;
 import com.velocity.api.user.exception.EmailAlreadyRegisteredException;
 import com.velocity.api.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -65,5 +68,14 @@ public class AdminUserService {
         }
 
         user.updateProfileByAdmin(fullName, phone, city, email);
+    }
+
+    @Transactional
+    public void updateUserRole(UUID id, UUID authenticatedUserId, AdminUserUpdateRoleRequest request) {
+        if (authenticatedUserId.equals(id)) {
+            throw new CannotDemoteSelfException("Administrators cannot change their own roles.");
+        }
+        User user = userRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("User not found."));
+        user.changeRoleByAdmin(request.role());
     }
 }


### PR DESCRIPTION
## Context

The admin dashboard requires the ability to upgrade standard users to administrators (and vice versa). This is implemented as a dedicated endpoint to isolate security transitions from standard profile updates, preventing accidental privilege escalation. 

Closes #80 

## What Changed

- Created `PATCH /api/v1/admin/users/{id}/role` endpoint specifically for security/role transitions.
- Created `AdminUserUpdateRoleRequest` DTO. Swapped `JsonNullable` for a strict `@NotNull UserRole` to ensure the action cannot be called with an empty payload.
- Adhered to ADR-002 (Rich Domain Model) by adding a dedicated `changeRoleByAdmin(UserRole role)` method inside the `User` entity.
- Implemented a backend hard-stop in the service layer to prevent administrators from accidentally demoting themselves (comparing `@AuthenticationPrincipal` ID with the target user ID).
- Added `CannotDemoteSelfException` mapped to a 409 Conflict via `ProblemDetail` (RFC 7807) in the `GlobalExceptionHandler`.

## Testing

- [x] Application compiles and starts successfully