### PR TITLE
feat: add reservation constraints

### DIFF
--- a/src/main/java/com/velocity/api/pricing/RentalCostCalculator.java
+++ b/src/main/java/com/velocity/api/pricing/RentalCostCalculator.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 @Component
 public class RentalCostCalculator {
@@ -17,9 +18,17 @@ public class RentalCostCalculator {
     }
 
     public BigDecimal calculate(int rentalDays) {
+        BigDecimal standardCost = this.dailyFlatRate.multiply(BigDecimal.valueOf(rentalDays));
+        final BigDecimal multiplier;
         if (rentalDays <= 0) {
             throw new IllegalArgumentException("The rental days should be greater than 0.");
+        } else if (rentalDays <= 7) {
+            multiplier = BigDecimal.ONE;
+        } else if (rentalDays <= 14) {
+            multiplier = new BigDecimal("0.80");
+        } else {
+            multiplier = new BigDecimal("0.60");
         }
-        return this.dailyFlatRate.multiply(BigDecimal.valueOf(rentalDays));
+        return standardCost.multiply(multiplier).setScale(2, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/com/velocity/api/reservation/Reservation.java
+++ b/src/main/java/com/velocity/api/reservation/Reservation.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 @Getter
@@ -69,6 +70,13 @@ public class Reservation {
     }
 
     private Reservation(User user, BikeInstance bikeInstance, LocalDate startDate, LocalDate endDate, BigDecimal totalCost) {
+        long days = ChronoUnit.DAYS.between(startDate, endDate);
+        if (days < 3 || days > 21) {
+            throw new IllegalArgumentException("Amount of days cannot be greater than 21 or smaller than 3.");
+        }
+        if (!endDate.isAfter(startDate)) {
+            throw new IllegalArgumentException("End date must be greater than Start date.");
+        }
         this.user = user;
         this.bikeInstance = bikeInstance;
         this.startDate = startDate;

--- a/src/main/java/com/velocity/api/reservation/dto/ReservationBookRequest.java
+++ b/src/main/java/com/velocity/api/reservation/dto/ReservationBookRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 public record ReservationBookRequest(
@@ -19,8 +20,15 @@ public record ReservationBookRequest(
         LocalDate endDate) {
     @AssertTrue(message = "End date must be strictly after start date")
     // if false, validator immediately halts execution and throws a MethodArgumentNotValidException.
-    public boolean isValidDateRange() {
+    public boolean isValidDateOrder() {
         if (startDate == null || endDate == null) return true;
         return endDate.isAfter(startDate);
+    }
+
+    @AssertTrue(message = "Rental duration must be between 3 and 21 days")
+    public boolean isDurationValid() {
+        if (startDate == null || endDate == null) return true;
+        long days = ChronoUnit.DAYS.between(startDate, endDate);
+        return days >= 3 && days <= 21;
     }
 }

--- a/src/test/java/com/velocity/api/pricing/RentalCostCalculatorTest.java
+++ b/src/test/java/com/velocity/api/pricing/RentalCostCalculatorTest.java
@@ -14,7 +14,7 @@ public class RentalCostCalculatorTest {
 
     @Test
     // Information about business logic behind the method
-    @DisplayName("Cost is exactly the flat rate multiplied by the number of rental days")
+    @DisplayName("Cost is exactly the flat rate multiplied by the number of rental days - test standard rate tier (3-7 days)")
     //MethodName_State_Expectation
     public void calculate_positiveDaysAndRate_returnsMultipliedTotal() {
         // 1. Arrange
@@ -48,5 +48,79 @@ public class RentalCostCalculatorTest {
 
         // Act & Assert
         assertThrows(IllegalArgumentException.class, () -> calculator.calculate(rentalDays));
+    }
+
+    @Test
+    @DisplayName("Tier 1 Upper Boundary: 7 days applies no discount")
+    public void calculate_exactlySevenDays_returnsStandardTotal() {
+        // Arrange
+        RentalCostCalculator calculator = new RentalCostCalculator(new BigDecimal("10.00"));
+        BigDecimal expectedCost = new BigDecimal("70.00");
+
+        // Act
+        BigDecimal actualCost = calculator.calculate(7);
+
+        // Assert
+        assertThat(actualCost).isEqualByComparingTo(expectedCost);
+    }
+
+    @Test
+    @DisplayName("Tier 2 Lower Boundary: 8 days applies 20% discount")
+    public void calculate_eightDays_appliesTwentyPercentDiscount() {
+        // Arrange
+        RentalCostCalculator calculator = new RentalCostCalculator(new BigDecimal("10.00"));
+        // Base is 80, 20% off is 16. Total: 64.
+        BigDecimal expectedCost = new BigDecimal("64.00");
+
+        // Act
+        BigDecimal actualCost = calculator.calculate(8);
+
+        // Assert
+        assertThat(actualCost).isEqualByComparingTo(expectedCost);
+    }
+
+    @Test
+    @DisplayName("Tier 2 Upper Boundary: 14 days applies 20% discount")
+    public void calculate_fourteenDays_appliesTwentyPercentDiscount() {
+        // Arrange
+        RentalCostCalculator calculator = new RentalCostCalculator(new BigDecimal("10.00"));
+        // Base is 140, 20% off is 28. Total: 112.
+        BigDecimal expectedCost = new BigDecimal("112.00");
+
+        // Act
+        BigDecimal actualCost = calculator.calculate(14);
+
+        // Assert
+        assertThat(actualCost).isEqualByComparingTo(expectedCost);
+    }
+
+    @Test
+    @DisplayName("Tier 3 Lower Boundary: 15 days applies 40% discount")
+    public void calculate_fifteenDays_appliesFortyPercentDiscount() {
+        // Arrange
+        RentalCostCalculator calculator = new RentalCostCalculator(new BigDecimal("10.00"));
+        // Base is 150, 40% off is 60. Total: 90.
+        BigDecimal expectedCost = new BigDecimal("90.00");
+
+        // Act
+        BigDecimal actualCost = calculator.calculate(15);
+
+        // Assert
+        assertThat(actualCost).isEqualByComparingTo(expectedCost);
+    }
+
+    @Test
+    @DisplayName("Tier 3 Upper Boundary: 21 days applies 40% discount")
+    public void calculate_twentyOneDays_appliesFortyPercentDiscount() {
+        // Arrange
+        RentalCostCalculator calculator = new RentalCostCalculator(new BigDecimal("10.00"));
+        // Base is 210, 40% off is 84. Total: 126.
+        BigDecimal expectedCost = new BigDecimal("126.00");
+
+        // Act
+        BigDecimal actualCost = calculator.calculate(21);
+
+        // Assert
+        assertThat(actualCost).isEqualByComparingTo(expectedCost);
     }
 }


### PR DESCRIPTION
## Context

To support our commercial rental model, we need to enforce strict limits on reservation lengths and introduce a tiered pricing system to incentivize longer rentals. This PR enforces the 3-21 day booking limit and implements the progressive discount engine.

Closes #82 

## What Changed

- **API Boundary Validation:** Added `@AssertTrue` validation in `ReservationBookRequest` DTO to enforce the 3-21 day duration limit, returning a clean 400 Bad Request for bad inputs.
- **Rich Domain Model (ADR-002):** Added guard clauses to the `Reservation` entity constructor to completely prevent the instantiation of invalid reservations (negative durations, out-of-bounds days). 
- **Tiered Pricing Engine:** Refactored `RentalCostCalculator` to act as a pure mathematical engine, applying cascading multipliers (1.00, 0.80, 0.60) based on rental length. 
- **BigDecimal Safety:** Implemented deferred initialization (`final BigDecimal multiplier`) and strict `String` constructors for all percentage math to eliminate floating-point precision loss.

## Testing

- [x] Unit tests written and passing
- [x] Application compiles and starts successfully

## Notes FOR the Reviewer

- **Testing Strategy:** The `RentalCostCalculatorTest` suite now utilizes strict Boundary Value Analysis, specifically testing the exact edge cases of our discount tiers (7, 8, 14, 15, and 21 days). 
- **Date Math:** We use `ChronoUnit.DAYS.between(start, end)` across the board, which treats the `endDate` as exclusive, aligning with our database exclusion constraint logic from ADR-001.