### PR TITLE
feat: add reservatino cancellation by user endpoint with logic

### DIFF
--- a/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.velocity.api.common.exception;
 import com.velocity.api.bike.exception.BikeNotAvailableException;
 import com.velocity.api.bike.exception.InvalidBikeStateException;
 import com.velocity.api.reservation.exception.InvalidStatusTransitionException;
+import com.velocity.api.reservation.exception.LateCancelException;
 import com.velocity.api.user.exception.CannotDemoteSelfException;
 import com.velocity.api.user.exception.EmailAlreadyRegisteredException;
 import com.velocity.api.user.exception.InvalidUserStateException;
@@ -252,6 +253,17 @@ public class GlobalExceptionHandler {
                 ex.getMessage()
         );
         problem.setTitle("Self-demotion attempt blocked");
+        return problem;
+    }
+
+    @ExceptionHandler(LateCancelException.class)
+    public ProblemDetail handleLateCancellationException(LateCancelException ex) {
+        log.warn("Late cancellation attempt blocked: {}", ex.getMessage());
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                ex.getMessage()
+        );
+        problem.setTitle("Late Cancellation Policy Violation");
         return problem;
     }
 

--- a/src/main/java/com/velocity/api/reservation/Reservation.java
+++ b/src/main/java/com/velocity/api/reservation/Reservation.java
@@ -2,6 +2,7 @@ package com.velocity.api.reservation;
 
 import com.velocity.api.bike.BikeInstance;
 import com.velocity.api.reservation.exception.InvalidStatusTransitionException;
+import com.velocity.api.reservation.exception.LateCancelException;
 import com.velocity.api.user.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -49,7 +50,7 @@ public class Reservation {
         this.createdAt = Instant.now();
     }
 
-    public void transitionTo(ReservationStatus newStatus) {
+    public void transitionTo(ReservationStatus newStatus) throws LateCancelException {
         if (this.status == newStatus) return;
 
         boolean isValid = switch (this.status) {
@@ -60,6 +61,10 @@ public class Reservation {
 
         if (!isValid) {
             throw new InvalidStatusTransitionException(this.status, newStatus);
+        }
+
+        if (newStatus.equals(ReservationStatus.CANCELLED) && LocalDate.now().isAfter(this.startDate)) {
+            throw new LateCancelException("The reservation cannot be cancelled after end date.");
         }
 
         this.status = newStatus;

--- a/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
+++ b/src/main/java/com/velocity/api/reservation/controller/ReservationController.java
@@ -6,6 +6,7 @@ import com.velocity.api.reservation.dto.AvailableModelResponse;
 import com.velocity.api.reservation.dto.ReservationBookRequest;
 import com.velocity.api.reservation.dto.ReservationBookResponse;
 import com.velocity.api.reservation.dto.ReservationResponse;
+import com.velocity.api.reservation.exception.LateCancelException;
 import com.velocity.api.reservation.service.ReservationService;
 import com.velocity.api.security.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -60,6 +61,13 @@ public class ReservationController {
     public ResponseEntity<Void> confirmReservation(@PathVariable UUID id, @AuthenticationPrincipal CustomUserDetails userDetails) throws AccessDeniedException {
         UUID authenticatedUserId = userDetails.getId();
         reservationService.confirmReservation(id, authenticatedUserId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/cancel")
+    public ResponseEntity<Void> cancelReservation(@PathVariable UUID id, @AuthenticationPrincipal CustomUserDetails userDetails) throws LateCancelException {
+        UUID authenticatedUserId = userDetails.getId();
+        reservationService.cancelReservation(id, authenticatedUserId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/velocity/api/reservation/exception/LateCancelException.java
+++ b/src/main/java/com/velocity/api/reservation/exception/LateCancelException.java
@@ -1,0 +1,7 @@
+package com.velocity.api.reservation.exception;
+
+public class LateCancelException extends RuntimeException {
+    public LateCancelException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/velocity/api/reservation/service/ReservationService.java
+++ b/src/main/java/com/velocity/api/reservation/service/ReservationService.java
@@ -12,6 +12,7 @@ import com.velocity.api.common.exception.ResourceNotFoundException;
 import com.velocity.api.reservation.Reservation;
 import com.velocity.api.reservation.ReservationStatus;
 import com.velocity.api.reservation.dto.*;
+import com.velocity.api.reservation.exception.LateCancelException;
 import com.velocity.api.reservation.mapper.ReservationMapper;
 import com.velocity.api.reservation.repository.ReservationRepository;
 import com.velocity.api.user.User;
@@ -138,5 +139,16 @@ public class ReservationService {
         }
 
         reservation.transitionTo(ReservationStatus.CONFIRMED);
+    }
+
+    @Transactional
+    public void cancelReservation(UUID reservationId, UUID userId) throws LateCancelException {
+        Reservation reservation = reservationRepository.findById(reservationId).orElseThrow(() -> new ResourceNotFoundException("Reservation not found"));
+
+        if (!(reservation.getUser().getId().equals(userId))) {
+            throw new AuthorizationDeniedException("The User cannot access the reservation of other user");
+        }
+
+        reservation.transitionTo(ReservationStatus.CANCELLED);
     }
 }

--- a/src/test/java/com/velocity/api/reservation/ReservationTest.java
+++ b/src/test/java/com/velocity/api/reservation/ReservationTest.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.time.LocalDate;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ReservationTest {
@@ -21,6 +23,7 @@ public class ReservationTest {
     public void transitionTo_validStates_updatesStatus(ReservationStatus from, ReservationStatus to) {
         Reservation reservation = new Reservation();
         ReflectionTestUtils.setField(reservation, "status", from);
+        ReflectionTestUtils.setField(reservation, "startDate", LocalDate.now().plusDays(1));
 
         reservation.transitionTo(to);
 


### PR DESCRIPTION
## Context

Users needed the ability to cancel their upcoming e-bike reservations to free up inventory and prevent no-shows. However, we needed to strictly enforce two business rules: users can only cancel their *own* reservations, and they cannot cancel a reservation if the rental period has already begun (late cancellation).

Closes #86

## What Changed

- Added `POST /api/v1/reservations/{id}/cancel` endpoint to the `ReservationController`.
- Implemented `cancelReservation` in `ReservationService` to fetch the entity and verify user ownership (throws `AuthorizationDeniedException` if mismatched).
- Shifted core date-validation logic into the `Reservation` entity per 0002-adopt-rich-domain-model-architecture.md. The entity now throws a custom `LateCancelException` if `LocalDate.now().isAfter(startDate)` during a transition to `CANCELLED`.
- Created `LateCancelException` and mapped it in `GlobalExceptionHandler` to return a standardized `400 Bad Request` `ProblemDetail`.

## Testing

- [x] Application compiles and starts successfully