### PR TITLE
feat: add user blocking logic

### DIFF
--- a/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/velocity/api/common/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.LockedException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -264,6 +265,17 @@ public class GlobalExceptionHandler {
                 ex.getMessage()
         );
         problem.setTitle("Late Cancellation Policy Violation");
+        return problem;
+    }
+
+    @ExceptionHandler(LockedException.class)
+    public ProblemDetail handleLockedException(LockedException ex) {
+        log.warn("The account is blocked: {}", ex.getMessage());
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.UNAUTHORIZED,
+                "Your account has been blocked. Please contact support."
+        );
+        problem.setTitle("Account has been blocked");
         return problem;
     }
 

--- a/src/main/java/com/velocity/api/security/CustomUserDetails.java
+++ b/src/main/java/com/velocity/api/security/CustomUserDetails.java
@@ -1,6 +1,7 @@
 package com.velocity.api.security;
 
 import com.velocity.api.common.City;
+import com.velocity.api.user.UserStatus;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.GrantedAuthority;
@@ -14,6 +15,7 @@ public record CustomUserDetails(
         String username,
         String password,
         City city,
+        UserStatus status,
         Collection<? extends GrantedAuthority> authorities) implements UserDetails {
 
     @Override
@@ -39,4 +41,8 @@ public record CustomUserDetails(
         return username;
     }
 
+    @Override
+    public boolean isAccountNonLocked() {
+        return this.status != UserStatus.BLOCKED;
+    }
 }

--- a/src/main/java/com/velocity/api/security/CustomUserDetailsService.java
+++ b/src/main/java/com/velocity/api/security/CustomUserDetailsService.java
@@ -21,6 +21,6 @@ public class CustomUserDetailsService implements UserDetailsService {
     public @NonNull UserDetails loadUserByUsername(@NonNull String username) {
         User user = userRepository.findByEmail(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User does not exists."));
-        return new CustomUserDetails(user.getId(), user.getEmail(), user.getPasswordHash(), user.getCity(), List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())));
+        return new CustomUserDetails(user.getId(), user.getEmail(), user.getPasswordHash(), user.getCity(), user.getStatus(), List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name())));
     }
 }

--- a/src/main/java/com/velocity/api/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/velocity/api/security/JwtAuthenticationFilter.java
@@ -42,6 +42,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 filterChain.doFilter(request, response);
                 return;
             }
+
+            String userId = jwtService.extractClaim(rawToken, "userId", String.class);
+            if (userId != null && tokenBlacklistRepository.isUserBlacklisted(userId)) {
+                log.warn("The user is blacklisted.");
+                filterChain.doFilter(request, response);
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Account has been blocked");
+                return;
+            }
+
             String username = jwtService.extractUsername(rawToken);
             if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
                 UserDetails userDetails = userDetailsService.loadUserByUsername(username);

--- a/src/main/java/com/velocity/api/security/JwtService.java
+++ b/src/main/java/com/velocity/api/security/JwtService.java
@@ -7,6 +7,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import javax.crypto.SecretKey;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
@@ -52,5 +53,9 @@ public class JwtService {
                 .expiration(new Date(System.currentTimeMillis() + jwtExpiration))
                 .signWith(getSignInKey())
                 .compact();
+    }
+
+    public Duration getJwtExpirationDuration() {
+        return Duration.ofMillis(jwtExpiration);
     }
 }

--- a/src/main/java/com/velocity/api/security/repository/TokenBlacklistRepository.java
+++ b/src/main/java/com/velocity/api/security/repository/TokenBlacklistRepository.java
@@ -20,4 +20,14 @@ public class TokenBlacklistRepository {
     public boolean isBlacklisted(String token) {
         return Boolean.TRUE.equals(stringRedisTemplate.hasKey(KEY_PREFIX + token));
     }
+
+    public void blacklistUser(String userId, Duration ttl) {
+        if (ttl.isNegative() || ttl.isZero()) return;
+        stringRedisTemplate.opsForValue().set(KEY_PREFIX + "user:" + userId, "blacklisted", ttl);
+    }
+
+    public boolean isUserBlacklisted(String userId) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(KEY_PREFIX + "user:" + userId));
+
+    }
 }

--- a/src/main/java/com/velocity/api/user/controller/AdminUserController.java
+++ b/src/main/java/com/velocity/api/user/controller/AdminUserController.java
@@ -33,8 +33,9 @@ public class AdminUserController {
     }
 
     @PostMapping("/users/{id}/block")
-    public ResponseEntity<Void> blockUser(@PathVariable("id") UUID id) {
-        adminUserService.blockUser(id);
+    public ResponseEntity<Void> blockUser(@PathVariable("id") UUID id, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        UUID authenticatedAdminId = userDetails.getId();
+        adminUserService.blockUser(id, authenticatedAdminId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/velocity/api/user/service/AdminUserService.java
+++ b/src/main/java/com/velocity/api/user/service/AdminUserService.java
@@ -2,6 +2,8 @@ package com.velocity.api.user.service;
 
 import com.velocity.api.common.City;
 import com.velocity.api.common.exception.ResourceNotFoundException;
+import com.velocity.api.security.JwtService;
+import com.velocity.api.security.repository.TokenBlacklistRepository;
 import com.velocity.api.user.User;
 import com.velocity.api.user.UserRole;
 import com.velocity.api.user.dto.AdminUserResponse;
@@ -17,6 +19,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.UUID;
 
 @Service
@@ -24,6 +27,8 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class AdminUserService {
     private final UserRepository userRepository;
+    private final TokenBlacklistRepository tokenBlacklistRepository;
+    private final JwtService jwtService;
 
     public Page<AdminUserResponse> listUsers(Pageable pageable) {
         return userRepository.findAll(pageable)
@@ -38,9 +43,14 @@ public class AdminUserService {
     }
 
     @Transactional
-    public void blockUser(UUID id) {
+    public void blockUser(UUID id, UUID authenticatedAdminId) {
+        if(authenticatedAdminId.equals(id)) {
+            throw new CannotDemoteSelfException("Administrators cannot block their own accounts.");
+        }
         User user = userRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("User not found."));
         user.block();
+        Duration tokenExpirationDuration = jwtService.getJwtExpirationDuration();
+        tokenBlacklistRepository.blacklistUser(String.valueOf(id), tokenExpirationDuration);
     }
 
     @Transactional

--- a/src/main/resources/db/changelog/dev/006-dev-seed.xml
+++ b/src/main/resources/db/changelog/dev/006-dev-seed.xml
@@ -2,68 +2,153 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-    <changeSet author="velocity-dev" id="007-dev-seed-data" context="dev" runOnChange="true">
+    <changeSet author="velocity-dev" id="006-dev-seed-data" context="dev" runOnChange="true">
         <sql>
             -- ═══════════════════════════════════ USERS ═══════════════════════════════════
             INSERT INTO users (id, full_name, email, password_hash, phone, role, status, city, joined_date)
-            VALUES ('11111111-1111-1111-1111-111111111111', 'Alice Smith', 'alice@velocity.com', 'hashed_pw_1',
-                    '+48123456789', 'CLIENT', 'ACTIVE', 'WARSAW', '2026-06-01'),
-                   ('22222222-2222-2222-2222-222222222222', 'Bob Jones', 'bob@velocity.com', 'hashed_pw_2',
-                    '+48987654321', 'CLIENT', 'ACTIVE', 'WROCLAW', '2026-06-15'),
-                   ('44444444-4444-4444-4444-444444444444', 'Dave Blocked', 'dave@velocity.com', 'hashed_pw_4',
-                    '+48111222333', 'CLIENT', 'BLOCKED', 'GDANSK', '2026-05-01'),
-                   ('33333333-3333-3333-3333-333333333333', 'Charlie Admin', 'admin@velocity.com',
+            VALUES ('3e2d1c0b-9f8e-4a7b-6c5d-4f3e2d1c0b9a', 'Charlie Admin', 'admin@velocity.com',
                     '$2a$10$8MJj/eiNAhpb0lvUIxHnxut7UiMsD7pdsTdUJGxsrtebf6TCF4onG',
-                    '+48000000000', 'ADMIN', 'ACTIVE', 'GDANSK', '2026-01-01') ON CONFLICT (id) DO NOTHING;
+                    '+48500000101', 'ADMIN', 'ACTIVE', 'GDANSK', '2026-01-01'),
+                   ('4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'Bob Jones', 'client@velocity.com',
+                    '$2a$12$PMDhJS9InPN5vMXXUcVXIugrwLi01r.yY8BKiSkkErmO5ps6KP/RS',
+                    '+49305550192', 'CLIENT', 'ACTIVE', 'WROCLAW', '2026-06-15'),
+                   ('d8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'Alice Smith', 'alice@velocity.com',
+                    '$2a$12$b7rFfC2KJ56zJSgsF.baA.0S7B8prHnzeC14CASWB9rrUd8p2.Yu2',
+                    '+442079460912', 'CLIENT', 'ACTIVE', 'WARSAW', '2026-07-01'),
+                   ('7c4b2a1f-8e9d-4f3a-bc12-9e8d7f6c5b4a', 'Dave Blocked', 'dave@velocity.com',
+                    '$2a$12$K/4OXWmX2L3HP0cGy0pquO.h8lIaYT05ba86SglUc4fFdRbUvJpcm',
+                    '+33140050011', 'CLIENT', 'BLOCKED', 'POZNAN', '2026-05-01')
+                ON CONFLICT (id) DO NOTHING;
 
             -- ══════════════════════════════════ BIKE MODELS ══════════════════════════════════
             INSERT INTO bike_models (id, name, category, description, speed, range, capacity)
-            VALUES ('aaaa0000-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'Sprint Courier S1', 'AGILITY',
+            VALUES ('b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e', 'Sprint Courier S1', 'AGILITY',
                     'Lightweight city courier, agile enough to weave through traffic. Perfect for backpack delivery.',
                     45, 80, 40),
-                   ('bbbb0000-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'Endurance Pro 2.0', 'DUAL_BATTERY',
+                   ('3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e', 'Endurance Pro 2.0', 'DUAL_BATTERY',
                     'Built for the 10-hour shift. Dual-battery ensures you never run out during the dinner rush.', 35,
                     100, 60),
-                   ('cccc0000-cccc-cccc-cccc-cccccccccccc', 'Cargo King XL', 'HEAVY_DUTY',
+                   ('7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f', 'Cargo King XL', 'HEAVY_DUTY',
                     '10 pizzas? No problem. Features insulated front box and heavy-duty rear rack.', 25, 60,
-                    100) ON CONFLICT (id) DO NOTHING;
+                    100)
+                ON CONFLICT (id) DO NOTHING;
 
             -- ══════════════════════════════════ BIKE INSTANCES ══════════════════════════════════
             INSERT INTO bike_instances (id, city, status, bike_model_id)
-            VALUES ('a1111111-1111-1111-1111-111111111111', 'WARSAW', 'ACTIVE', 'aaaa0000-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
-                   ('a2222222-2222-2222-2222-222222222222', 'WARSAW', 'ACTIVE', 'aaaa0000-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
-                   ('a3333333-3333-3333-3333-333333333333', 'WARSAW', 'MAINTENANCE',
-                    'aaaa0000-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
-                   ('b1111111-1111-1111-1111-111111111111', 'WROCLAW', 'ACTIVE',
-                    'bbbb0000-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
-                   ('b2222222-2222-2222-2222-222222222222', 'WROCLAW', 'ACTIVE',
-                    'bbbb0000-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
-                   ('b3333333-3333-3333-3333-333333333333', 'WROCLAW', 'RETIRED',
-                    'bbbb0000-bbbb-bbbb-bbbb-bbbbbbbbbbbb'),
-                   ('c1111111-1111-1111-1111-111111111111', 'GDANSK', 'ACTIVE', 'cccc0000-cccc-cccc-cccc-cccccccccccc'),
-                   ('c2222222-2222-2222-2222-222222222222', 'GDANSK', 'LOST', 'cccc0000-cccc-cccc-cccc-cccccccccccc'),
-                   ('c3333333-3333-3333-3333-333333333333', 'GDANSK', 'ACTIVE', 'cccc0000-cccc-cccc-cccc-cccccccccccc'),
-                   ('d1111111-1111-1111-1111-111111111111', 'POZNAN', 'ACTIVE', 'aaaa0000-aaaa-aaaa-aaaa-aaaaaaaaaaaa'),
-                   ('d2222222-2222-2222-2222-222222222222', 'POZNAN', 'ACTIVE',
-                    'aaaa0000-aaaa-aaaa-aaaa-aaaaaaaaaaaa') ON CONFLICT (id) DO NOTHING;
+            VALUES
+                -- WARSAW (12 Active, 2 Maintenance, 1 Retired)
+                ('a1a1a1a1-1111-4111-8111-000000000001', 'WARSAW', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('a1a1a1a1-1111-4111-8111-000000000002', 'WARSAW', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('a1a1a1a1-1111-4111-8111-000000000003', 'WARSAW', 'ACTIVE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('a1a1a1a1-1111-4111-8111-000000000004', 'WARSAW', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('a1a1a1a1-1111-4111-8111-000000000005', 'WARSAW', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('a1a1a1a1-1111-4111-8111-000000000006', 'WARSAW', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('a1a1a1a1-1111-4111-8111-000000000007', 'WARSAW', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('a1a1a1a1-1111-4111-8111-000000000008', 'WARSAW', 'ACTIVE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('a1a1a1a1-1111-4111-8111-000000000009', 'WARSAW', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('a1a1a1a1-1111-4111-8111-000000000010', 'WARSAW', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('a1a1a1a1-1111-4111-8111-000000000011', 'WARSAW', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('a1a1a1a1-1111-4111-8111-000000000012', 'WARSAW', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('a1a1a1a1-1111-4111-8111-000000000013', 'WARSAW', 'MAINTENANCE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('a1a1a1a1-1111-4111-8111-000000000014', 'WARSAW', 'LOST', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('a1a1a1a1-1111-4111-8111-000000000015', 'WARSAW', 'RETIRED', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                -- WROCLAW (12 Active, 2 Maintenance, 1 Retired)
+                ('b2b2b2b2-2222-4222-8222-000000000001', 'WROCLAW', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('b2b2b2b2-2222-4222-8222-000000000002', 'WROCLAW', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('b2b2b2b2-2222-4222-8222-000000000003', 'WROCLAW', 'ACTIVE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('b2b2b2b2-2222-4222-8222-000000000004', 'WROCLAW', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('b2b2b2b2-2222-4222-8222-000000000005', 'WROCLAW', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('b2b2b2b2-2222-4222-8222-000000000006', 'WROCLAW', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('b2b2b2b2-2222-4222-8222-000000000007', 'WROCLAW', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('b2b2b2b2-2222-4222-8222-000000000008', 'WROCLAW', 'ACTIVE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('b2b2b2b2-2222-4222-8222-000000000009', 'WROCLAW', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('b2b2b2b2-2222-4222-8222-000000000010', 'WROCLAW', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('b2b2b2b2-2222-4222-8222-000000000011', 'WROCLAW', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('b2b2b2b2-2222-4222-8222-000000000012', 'WROCLAW', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('b2b2b2b2-2222-4222-8222-000000000113', 'WROCLAW', 'MAINTENANCE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('b2b2b2b2-2222-4222-8222-000000000114', 'WROCLAW', 'LOST', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('b2b2b2b2-2222-4222-8222-000000000115', 'WROCLAW', 'RETIRED', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                -- GDANSK (12 Active, 2 Maintenance, 1 Retired)
+                ('c3c3c3c3-3333-4333-8333-000000000001', 'GDANSK', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('c3c3c3c3-3333-4333-8333-000000000002', 'GDANSK', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('c3c3c3c3-3333-4333-8333-000000000003', 'GDANSK', 'ACTIVE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('c3c3c3c3-3333-4333-8333-000000000004', 'GDANSK', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('c3c3c3c3-3333-4333-8333-000000000005', 'GDANSK', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('c3c3c3c3-3333-4333-8333-000000000006', 'GDANSK', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('c3c3c3c3-3333-4333-8333-000000000007', 'GDANSK', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('c3c3c3c3-3333-4333-8333-000000000008', 'GDANSK', 'ACTIVE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('c3c3c3c3-3333-4333-8333-000000000009', 'GDANSK', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('c3c3c3c3-3333-4333-8333-000000000010', 'GDANSK', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('c3c3c3c3-3333-4333-8333-000000000011', 'GDANSK', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('c3c3c3c3-3333-4333-8333-000000000012', 'GDANSK', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('c3c3c3c3-3333-4333-8333-000000000113', 'GDANSK', 'MAINTENANCE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('c3c3c3c3-3333-4333-8333-000000000114', 'GDANSK', 'LOST', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('c3c3c3c3-3333-4333-8333-000000000115', 'GDANSK', 'RETIRED', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                -- POZNAN (12 Active, 2 Maintenance, 1 Retired)
+                ('d4d4d4d4-4444-4444-8444-000000000001', 'POZNAN', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('d4d4d4d4-4444-4444-8444-000000000002', 'POZNAN', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('d4d4d4d4-4444-4444-8444-000000000003', 'POZNAN', 'ACTIVE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('d4d4d4d4-4444-4444-8444-000000000004', 'POZNAN', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('d4d4d4d4-4444-4444-8444-000000000005', 'POZNAN', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('d4d4d4d4-4444-4444-8444-000000000006', 'POZNAN', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('d4d4d4d4-4444-4444-8444-000000000007', 'POZNAN', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('d4d4d4d4-4444-4444-8444-000000000008', 'POZNAN', 'ACTIVE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('d4d4d4d4-4444-4444-8444-000000000009', 'POZNAN', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('d4d4d4d4-4444-4444-8444-000000000010', 'POZNAN', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('d4d4d4d4-4444-4444-8444-000000000011', 'POZNAN', 'ACTIVE', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('d4d4d4d4-4444-4444-8444-000000000012', 'POZNAN', 'ACTIVE', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e'),
+                ('d4d4d4d4-4444-4444-8444-000000000113', 'POZNAN', 'MAINTENANCE', '7e2d4c6b-8f1a-42c3-9b4e-1a2b3c4d5e6f'),
+                ('d4d4d4d4-4444-4444-8444-000000000114', 'POZNAN', 'LOST', 'b8f4c2e1-9a3d-47c2-8f1e-6d5c4b3a2f1e'),
+                ('d4d4d4d4-4444-4444-8444-000000000115', 'POZNAN', 'RETIRED', '3a1f9e8d-7c6b-45a4-92e1-0f4a3b2c1d9e')
+                ON CONFLICT (id) DO NOTHING;
 
             -- ══════════════════════════════════ RESERVATIONS ══════════════════════════════════
-            INSERT INTO reservations (id, start_date, end_date, total_cost, status, created_at, version, user_id,
-                                      bike_instance_id)
-            VALUES ('e1111111-1111-1111-1111-111111111111', '2026-06-01', '2026-06-05', 120.00, 'COMPLETED',
-                    '2026-05-28 10:00:00', 0, '11111111-1111-1111-1111-111111111111',
-                    'a1111111-1111-1111-1111-111111111111'),
-                   ('e2222222-2222-2222-2222-222222222222', '2026-07-10', '2026-07-15', 150.00, 'CONFIRMED',
-                    '2026-07-01 09:00:00', 0, '11111111-1111-1111-1111-111111111111',
-                    'a1111111-1111-1111-1111-111111111111'),
-                   ('e3333333-3333-3333-3333-333333333333', '2026-07-12', '2026-07-14', 60.00, 'CANCELLED',
-                    '2026-07-01 09:05:00', 0, '22222222-2222-2222-2222-222222222222',
-                    'a1111111-1111-1111-1111-111111111111'),
-                   ('e4444444-4444-4444-4444-444444444444', '2026-07-20', '2026-07-25', 150.00, 'PENDING',
-                    '2026-07-02 08:00:00', 0, '22222222-2222-2222-2222-222222222222',
-                    'b1111111-1111-1111-1111-111111111111') ON CONFLICT (id) DO NOTHING;
+            -- Pricing logic: 3-7 days (25 PLN), 8-14 days (20 PLN), 15-21 days (15 PLN).
+            -- Bounded between 3 and 21 days maximum.
+            INSERT INTO reservations (id, start_date, end_date, total_cost, status, created_at, version, user_id, bike_instance_id)
+            VALUES
+                -- June Historical (COMPLETED / CANCELLED)
+                (gen_random_uuid(), '2026-06-01', '2026-06-05', 100.00, 'COMPLETED', '2026-05-28 10:00:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'a1a1a1a1-1111-4111-8111-000000000001'), -- 4d * 25
+                (gen_random_uuid(), '2026-06-06', '2026-06-16', 200.00, 'COMPLETED', '2026-06-01 08:30:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'a1a1a1a1-1111-4111-8111-000000000002'), -- 10d * 20
+                (gen_random_uuid(), '2026-06-10', '2026-06-25', 225.00, 'COMPLETED', '2026-06-05 12:00:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'b2b2b2b2-2222-4222-8222-000000000001'), -- 15d * 15
+                (gen_random_uuid(), '2026-06-18', '2026-06-21', 75.00,  'COMPLETED', '2026-06-10 14:15:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'c3c3c3c3-3333-4333-8333-000000000001'), -- 3d * 25
+                (gen_random_uuid(), '2026-06-20', '2026-07-11', 315.00, 'COMPLETED', '2026-06-12 09:00:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'd4d4d4d4-4444-4444-8444-000000000001'), -- 21d * 15
+                (gen_random_uuid(), '2026-06-25', '2026-06-30', 125.00, 'CANCELLED', '2026-06-20 11:00:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'a1a1a1a1-1111-4111-8111-000000000003'), -- 5d * 25
+
+                -- July Historical (COMPLETED / CANCELLED)
+                (gen_random_uuid(), '2026-07-01', '2026-07-04', 75.00,  'COMPLETED', '2026-06-28 07:30:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'a1a1a1a1-1111-4111-8111-000000000004'), -- 3d * 25
+                (gen_random_uuid(), '2026-07-05', '2026-07-14', 180.00, 'COMPLETED', '2026-07-01 10:20:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'b2b2b2b2-2222-4222-8222-000000000002'), -- 9d * 20
+                (gen_random_uuid(), '2026-07-10', '2026-07-17', 175.00, 'COMPLETED', '2026-07-05 16:00:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'c3c3c3c3-3333-4333-8333-000000000002'), -- 7d * 25
+                (gen_random_uuid(), '2026-07-12', '2026-07-15', 75.00,  'CANCELLED', '2026-07-06 09:10:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'd4d4d4d4-4444-4444-8444-000000000002'), -- 3d * 25
+                (gen_random_uuid(), '2026-07-15', '2026-07-29', 280.00, 'COMPLETED', '2026-07-10 11:45:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'a1a1a1a1-1111-4111-8111-000000000005'), -- 14d * 20
+                (gen_random_uuid(), '2026-07-18', '2026-07-24', 150.00, 'COMPLETED', '2026-07-12 14:30:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'b2b2b2b2-2222-4222-8222-000000000003'), -- 6d * 25
+                (gen_random_uuid(), '2026-07-22', '2026-07-25', 75.00,  'CANCELLED', '2026-07-15 08:00:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'c3c3c3c3-3333-4333-8333-000000000003'), -- 3d * 25
+                (gen_random_uuid(), '2026-07-25', '2026-08-10', 240.00, 'COMPLETED', '2026-07-20 17:15:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'd4d4d4d4-4444-4444-8444-000000000003'), -- 16d * 15
+                (gen_random_uuid(), '2026-07-28', '2026-08-01', 100.00, 'COMPLETED', '2026-07-22 10:00:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'a1a1a1a1-1111-4111-8111-000000000006'), -- 4d * 25
+
+                -- August Historical (COMPLETED / CANCELLED)
+                (gen_random_uuid(), '2026-08-01', '2026-08-06', 125.00, 'COMPLETED', '2026-07-25 09:30:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'b2b2b2b2-2222-4222-8222-000000000004'), -- 5d * 25
+                (gen_random_uuid(), '2026-08-03', '2026-08-14', 220.00, 'COMPLETED', '2026-07-28 11:00:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'c3c3c3c3-3333-4333-8333-000000000004'), -- 11d * 20
+                (gen_random_uuid(), '2026-08-08', '2026-08-11', 75.00,  'COMPLETED', '2026-08-01 13:20:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'd4d4d4d4-4444-4444-8444-000000000004'), -- 3d * 25
+                (gen_random_uuid(), '2026-08-12', '2026-08-17', 125.00, 'CANCELLED', '2026-08-05 08:45:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'a1a1a1a1-1111-4111-8111-000000000007'), -- 5d * 25
+                (gen_random_uuid(), '2026-08-15', '2026-09-02', 270.00, 'COMPLETED', '2026-08-10 10:10:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'b2b2b2b2-2222-4222-8222-000000000005'), -- 18d * 15
+                (gen_random_uuid(), '2026-08-18', '2026-08-25', 175.00, 'COMPLETED', '2026-08-12 16:30:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'c3c3c3c3-3333-4333-8333-000000000005'), -- 7d * 25
+                (gen_random_uuid(), '2026-08-22', '2026-08-25', 75.00,  'CANCELLED', '2026-08-15 09:00:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'd4d4d4d4-4444-4444-8444-000000000005'), -- 3d * 25
+                (gen_random_uuid(), '2026-08-25', '2026-09-04', 200.00, 'COMPLETED', '2026-08-20 11:20:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'a1a1a1a1-1111-4111-8111-000000000008'), -- 10d * 20
+                (gen_random_uuid(), '2026-08-28', '2026-09-17', 300.00, 'COMPLETED', '2026-08-22 14:00:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'b2b2b2b2-2222-4222-8222-000000000006'), -- 20d * 15
+
+                -- Recent/Current/Future (CONFIRMED / PENDING) - Dates after Sept 4, 2026
+                (gen_random_uuid(), '2026-09-05', '2026-09-10', 125.00, 'CONFIRMED', '2026-09-01 08:00:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'c3c3c3c3-3333-4333-8333-000000000006'), -- 5d * 25
+                (gen_random_uuid(), '2026-09-10', '2026-09-18', 160.00, 'CONFIRMED', '2026-09-02 10:30:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'd4d4d4d4-4444-4444-8444-000000000006'), -- 8d * 20
+                (gen_random_uuid(), '2026-09-15', '2026-10-05', 300.00, 'CONFIRMED', '2026-09-03 14:15:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'a1a1a1a1-1111-4111-8111-000000000009'), -- 20d * 15
+                (gen_random_uuid(), '2026-09-22', '2026-09-25', 75.00,  'CONFIRMED', '2026-09-04 09:00:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'b2b2b2b2-2222-4222-8222-000000000007'), -- 3d * 25
+                (gen_random_uuid(), '2026-10-01', '2026-10-15', 280.00, 'CONFIRMED', '2026-09-04 10:00:00', 0, '4f2c9a1b-7e8d-43c2-9f1e-5a8b7c2d3e4f', 'c3c3c3c3-3333-4333-8333-000000000007'), -- 14d * 20
+
+                -- The 1 PENDING Reservation (Created today at 16:30, expires 17:00)
+                (gen_random_uuid(), '2026-09-06', '2026-09-09', 75.00,  'PENDING',   '2026-09-04 16:30:00', 0, 'd8b2e1f4-9c3a-4e7f-8a12-6f3b9c8d2e1a', 'd4d4d4d4-4444-4444-8444-000000000007')  -- 3d * 25
+                ON CONFLICT (id) DO NOTHING;
         </sql>
     </changeSet>
 

--- a/src/test/java/com/velocity/api/security/SecurityTestHelper.java
+++ b/src/test/java/com/velocity/api/security/SecurityTestHelper.java
@@ -1,6 +1,7 @@
 package com.velocity.api.security;
 
 import com.velocity.api.common.City;
+import com.velocity.api.user.UserStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -19,6 +20,7 @@ public class SecurityTestHelper {
                 "test@test.com",
                 "password-not-needed",
                 City.GDANSK,
+                UserStatus.ACTIVE,
                 List.of(new SimpleGrantedAuthority("ROLE_" + role))
         );
 


### PR DESCRIPTION
## Context

Currently, users with a `BLOCKED` status in the database could still authenticate or continue using active, unexpired JWTs. This PR implements front-door login restrictions and an instant back-door session revocation mechanism to secure the platform against bad actors.

Closes #88 

## What Changed

- Implemented Spring Security's `UserDetails` contract, mapping `isAccountNonLocked()` directly to the domain status (`this.status != UserStatus.BLOCKED`).
- Added a `LockedException` handler inside `RestControllerAdvice` to cleanly map Spring Security's lockout state to a standardized `ProblemDetail` payload with a `401 Unauthorized` status and a user-friendly toast message.
- Extended `TokenBlacklistRepository` to support user-wide Redis kill switches (`auth:blacklist:user:{id}`) with a TTL matched to the application's maximum JWT lifespan.
- Updated `JwtAuthenticationFilter` to perform an instant, `O(1)` Redis lookup for blacklisted user IDs before establishing the security context.
- Implemented `UserService.blockUser()` adhering to ADR-002 (Rich Domain Model), including an explicit safety guard to prevent administrators from blocking their own accounts.
- Added `JwtService.getJwtExpirationDuration()` to encapsulate configuration lifespans cleanly away from the service layer.

## Testing

- [x] Application compiles and starts successfully